### PR TITLE
Initial implementation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eof=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Unit Tests
+on: [pull_request]
+jobs:
+    unittest:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Setup Golang
+              uses: actions/setup-go@v3
+              with:
+                go-version: 1.18
+            - name: Tests
+              run: make test
+    linter:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Setup Golang
+              uses: actions/setup-go@v3
+              with:
+                go-version: 1.18
+            - name: Golint
+              uses: golangci/golangci-linter@v3
+              with:
+                version: latest
+            

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+*.sw?
+
+# coverage data file
+.coverage

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+#Uncomment the below to enable detailed test information in the output
+#OPTIONS=-test.v
+
+test:
+	go test -cover -covermode=atomic -coverprofile=.coverage ./... $(OPTIONS)
+
+coverage: test
+	go tool cover -html=.coverage
+	go tool cover -func=.coverage

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,13 @@
+*************
+gostackinabox
+*************
+
+Testing framework for HTTP-based APIs
+
+========
+Overview
+========
+
+This is a port of ``StackInABox`` (https://github.com/TestInABox/stackInABox) to Golang.
+The Service design is slightly different to accomodate how Golang works and the fact that
+some things are built-in to Golang that are not in Python.

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,11 @@
+package client
+
+import (
+    "net/http"
+
+    "github.com/TestInABox/gostackinabox/router"
+)
+
+var DefaultClient = &http.Client{
+    Transport: &router.Router{},
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,13 @@
+package client_test
+
+import (
+    "testing"
+
+    "github.com/TestInABox/gostackinabox/client"
+)
+
+func Test_Client_DefaultClient(t *testing.T) {
+    if client.DefaultClient == nil {
+        t.Errorf("Unexpected nil client: %#v", client.DefaultClient)
+    }
+}

--- a/common/call.go
+++ b/common/call.go
@@ -1,0 +1,15 @@
+package common
+
+import (
+    "net/http"
+    "net/url"
+)
+
+type HttpCall struct {
+    // most of these fields are just
+    // easy access to the request information
+    Method  HttpVerb
+    Url     *url.URL
+    Headers http.Header
+    Request *http.Request
+}

--- a/common/call_test.go
+++ b/common/call_test.go
@@ -1,0 +1,21 @@
+package common_test
+
+import (
+    "net/http"
+    "net/url"
+    "testing"
+
+    "github.com/TestInABox/gostackinabox/common"
+)
+
+func Test_Common_HttpCall(t *testing.T) {
+    hc := &common.HttpCall{
+        Method: "test",
+        Url: &url.URL{},
+        Headers: http.Header{},
+        Request: &http.Request{},
+    }
+    if hc == nil {
+        t.Error("Unexpected nil")
+    }
+}

--- a/common/handler.go
+++ b/common/handler.go
@@ -1,0 +1,4 @@
+package common
+
+type HttpHandler func(*HttpCall) (*HttpReply, error)
+type HttpHandlerMap map[HttpVerb]HttpHandler

--- a/common/handler_test.go
+++ b/common/handler_test.go
@@ -1,0 +1,27 @@
+package common_test
+
+import (
+    "testing"
+
+    "github.com/TestInABox/gostackinabox/common"
+)
+
+func Test_Common_Handler(t *testing.T) {
+    fn := func(hc *common.HttpCall) (hr *common.HttpReply, err error) {
+        return
+    }
+
+    key := common.HttpVerb("test")
+    var hhm common.HttpHandlerMap = make(common.HttpHandlerMap)
+    if len(hhm) != 0 {
+        t.Errorf("Unepected non-empty map: length: %d, %#v", len(hhm), hhm)
+    }
+    hhm[key] = fn
+    if len(hhm) != 1 {
+        t.Errorf("Unepected map size: length: %d, %#v", len(hhm), hhm)
+    }
+
+    if _, ok := hhm[key]; !ok {
+        t.Errorf("Unexpectedly did not find the key (%s) in the map (%v)", key, hhm)
+    }
+}

--- a/common/log/log.go
+++ b/common/log/log.go
@@ -1,0 +1,101 @@
+package log
+
+import (
+    "fmt"
+    golog "log"
+)
+
+/*
+    The main purpose of these methods is to log all GoStackInABox messages with
+    the same prefix so that the logs are easy to identify and help users diagnose
+    what is going on in their tests.
+ */
+
+/***********************
+ *** Support versions ***
+ ***********************/
+
+const (
+    logName = "GoStackInABox"
+    logFmtString = "%s: %s"
+)
+
+type formattedFn func(string, ...interface{})
+type standardFn func(...interface{})
+
+var (
+    doFatalf formattedFn = golog.Fatalf
+    doFatal standardFn = golog.Fatal
+    doFatalln standardFn = golog.Fatalln
+
+    doPanicf formattedFn = golog.Panicf
+    doPanic standardFn = golog.Panic
+    doPanicln standardFn = golog.Panicln
+
+    doPrintf formattedFn = golog.Printf
+    doPrint standardFn = golog.Print
+    doPrintln standardFn = golog.Println
+)
+
+func makeLogStringf(format string, v ...interface{}) string {
+    coreLogString := fmt.Sprintf(format, v...)
+    return fmt.Sprintf(logFmtString, logName, coreLogString)
+}
+
+func makeLogString(v ...interface{}) string {
+    coreLogString := fmt.Sprint(v...)
+    return fmt.Sprintf(logFmtString, logName, coreLogString)
+}
+
+func makeLogStringln(v ...interface{}) string {
+    coreLogString := fmt.Sprintln(v...)
+    return fmt.Sprintf(logFmtString, logName, coreLogString)
+}
+
+/***********************
+ *** Printf versions ***
+ ***********************/
+
+func Fatalf(format string, v ...interface{}) {
+    doFatalf(makeLogStringf(format, v...))
+}
+
+func Panicf(format string, v ...interface{}) {
+    doPanicf(makeLogStringf(format, v...))
+}
+
+func Printf(format string, v ...interface{}) {
+    doPrintf(makeLogStringf(format, v...))
+}
+
+/**********************
+ *** Print versions ***
+ **********************/
+
+func Fatal(v ...interface{}) {
+    doFatal(makeLogString(v...))
+}
+
+func Panic(v ...interface{}) {
+    doPanic(makeLogString(v...))
+}
+
+func Print(v ...interface{}) {
+    doPrint(makeLogString(v...))
+}
+
+/************************
+ *** Println versions ***
+ ************************/
+
+func Fatalln(v ...interface{}) {
+    doFatalln(makeLogStringln(v...))
+}
+
+func Panicln(v ...interface{}) {
+    doPanicln(makeLogStringln(v...))
+}
+
+func Println(v ...interface{}) {
+    doPrintln(makeLogStringln(v...))
+}

--- a/common/log/log_test.go
+++ b/common/log/log_test.go
@@ -1,0 +1,177 @@
+package log
+// not `log_test` so that we can access the internal methods for better testing
+
+import (
+    "fmt"
+    "testing"
+
+    //"github.com/TestInABox/gostackinabox/common/log"
+)
+
+func Test_MakeLogString(t *testing.T) {
+    t.Run(
+        "format",
+        func(t *testing.T) {
+            expectedMsg := fmt.Sprintf("%s: hello world", logName)
+            result := makeLogStringf("%s %s", "hello", "world")
+            if result != expectedMsg {
+                t.Errorf("Log Messages do not match: \"%s\" != \"%s\"", result, expectedMsg)
+            }
+        },
+    )
+    t.Run(
+        "standard",
+        func(t *testing.T) {
+            expectedMsg := fmt.Sprintf("%s: hello world", logName)
+            result := makeLogString("hello world")
+            if result != expectedMsg {
+                t.Errorf("Log Messages do not match: \"%s\" != \"%s\"", result, expectedMsg)
+            }
+        },
+    )
+    t.Run(
+        "newline",
+        func(t *testing.T) {
+            expectedMsg := fmt.Sprintf("%s: hello world\n", logName)
+            result := makeLogStringln("hello world")
+            if result != expectedMsg {
+                t.Errorf("Log Messages do not match: \"%s\" != \"%s\"", result, expectedMsg)
+            }
+        },
+    )
+}
+
+func Test_FormattedLoggers(t *testing.T) {
+    t.Run(
+        "fatal",
+        func(t *testing.T) {
+            expectedMsg := fmt.Sprintf("%s: hello world", logName)
+            var result string
+            doFatalf = func(formatted string, v ...interface{}) {
+                result = fmt.Sprintf(formatted, v...)
+            }
+            Fatalf("%s %s", "hello", "world")
+            if result != expectedMsg {
+                t.Errorf("Log Messages do not match: \"%s\" != \"%s\"", result, expectedMsg)
+            }
+        },
+    )
+    t.Run(
+        "panic",
+        func(t *testing.T) {
+            expectedMsg := fmt.Sprintf("%s: hello world", logName)
+            var result string
+            doPanicf = func(formatted string, v ...interface{}) {
+                result = fmt.Sprintf(formatted, v...)
+            }
+            Panicf("%s %s", "hello", "world")
+            if result != expectedMsg {
+                t.Errorf("Log Messages do not match: \"%s\" != \"%s\"", result, expectedMsg)
+            }
+        },
+    )
+    t.Run(
+        "print",
+        func(t *testing.T) {
+            expectedMsg := fmt.Sprintf("%s: hello world", logName)
+            var result string
+            doPrintf = func(formatted string, v ...interface{}) {
+                result = fmt.Sprintf(formatted, v...)
+            }
+            Printf("%s %s", "hello", "world")
+            if result != expectedMsg {
+                t.Errorf("Log Messages do not match: \"%s\" != \"%s\"", result, expectedMsg)
+            }
+        },
+    )
+}
+
+func Test_StandardLoggers(t *testing.T) {
+    t.Run(
+        "fatal",
+        func(t *testing.T) {
+            expectedMsg := fmt.Sprintf("%s: hello world", logName)
+            var result string
+            doFatal = func(v ...interface{}) {
+                result = fmt.Sprint(v...)
+            }
+            Fatal("hello world")
+            if result != expectedMsg {
+                t.Errorf("Log Messages do not match: \"%s\" != \"%s\"", result, expectedMsg)
+            }
+        },
+    )
+    t.Run(
+        "panic",
+        func(t *testing.T) {
+            expectedMsg := fmt.Sprintf("%s: hello world", logName)
+            var result string
+            doPanic = func(v ...interface{}) {
+                result = fmt.Sprint(v...)
+            }
+            Panic("hello world")
+            if result != expectedMsg {
+                t.Errorf("Log Messages do not match: \"%s\" != \"%s\"", result, expectedMsg)
+            }
+        },
+    )
+    t.Run(
+        "print",
+        func(t *testing.T) {
+            expectedMsg := fmt.Sprintf("%s: hello world", logName)
+            var result string
+            doPrint = func(v ...interface{}) {
+                result = fmt.Sprint(v...)
+            }
+            Print("hello world")
+            if result != expectedMsg {
+                t.Errorf("Log Messages do not match: \"%s\" != \"%s\"", result, expectedMsg)
+            }
+        },
+    )
+}
+
+func Test_NewLineLoggers(t *testing.T) {
+    t.Run(
+        "fatal",
+        func(t *testing.T) {
+            expectedMsg := fmt.Sprintf("%s: hello world\n", logName)
+            var result string
+            doFatalln = func(v ...interface{}) {
+                result = fmt.Sprint(v...)
+            }
+            Fatalln("hello world")
+            if result != expectedMsg {
+                t.Errorf("Log Messages do not match: \"%s\" != \"%s\"", result, expectedMsg)
+            }
+        },
+    )
+    t.Run(
+        "panic",
+        func(t *testing.T) {
+            expectedMsg := fmt.Sprintf("%s: hello world\n", logName)
+            var result string
+            doPanicln = func(v ...interface{}) {
+                result = fmt.Sprint(v...)
+            }
+            Panicln("hello world")
+            if result != expectedMsg {
+                t.Errorf("Log Messages do not match: \"%s\" != \"%s\"", result, expectedMsg)
+            }
+        },
+    )
+    t.Run(
+        "print",
+        func(t *testing.T) {
+            expectedMsg := fmt.Sprintf("%s: hello world\n", logName)
+            var result string
+            doPrintln = func(v ...interface{}) {
+                result = fmt.Sprint(v...)
+            }
+            Println("hello world")
+            if result != expectedMsg {
+                t.Errorf("Log Messages do not match: \"%s\" != \"%s\"", result, expectedMsg)
+            }
+        },
+    )
+}

--- a/common/reply.go
+++ b/common/reply.go
@@ -1,0 +1,14 @@
+package common
+
+import (
+    "net/http"
+    "io"
+)
+
+type HttpReply struct {
+    Status       HttpStatusCode
+    Headers      http.Header
+    Trailers     http.Header
+    ResponseData io.ReadCloser
+    Length       int64
+}

--- a/common/reply_test.go
+++ b/common/reply_test.go
@@ -1,0 +1,18 @@
+package common_test
+
+import (
+    "net/http"
+    "testing"
+
+    "github.com/TestInABox/gostackinabox/common"
+)
+
+func Test_Common_HttpReply(t *testing.T) {
+    hr := &common.HttpReply{
+        Status: common.HttpStatus_RouteNotHandled,
+        Headers: http.Header{},
+    }
+    if hr == nil {
+        t.Error("Unexpected nil")
+    }
+}

--- a/common/status.go
+++ b/common/status.go
@@ -1,0 +1,14 @@
+package common
+
+type HttpStatusCode int
+
+const (
+    HttpStatus_MethodNotSupport     HttpStatusCode = 405
+    HttpStatus_RouteNotHandled      HttpStatusCode = 595
+    HttpStatus_ServiceError         HttpStatusCode = 596
+    HttpStatus_ServiceSubRouteError HttpStatusCode = 597
+)
+
+func GetHttpStatus(code int) HttpStatusCode {
+    return HttpStatusCode(code)
+}

--- a/common/status_test.go
+++ b/common/status_test.go
@@ -1,0 +1,21 @@
+package common_test
+
+import (
+    "testing"
+
+    "github.com/TestInABox/gostackinabox/common"
+)
+
+func Test_Common_HttpStatus(t *testing.T) {
+    status := map[common.HttpStatusCode]int{}
+    status[common.HttpStatus_MethodNotSupport] = 405
+    status[common.HttpStatus_RouteNotHandled] = 595
+    status[common.HttpStatus_ServiceError] = 596
+    status[common.HttpStatus_ServiceSubRouteError] = 597
+
+    for v, k := range status {
+        if int(v) != k {
+            t.Errorf("Key Value %v != %v", v, k)
+        }
+    }
+}

--- a/common/uri.go
+++ b/common/uri.go
@@ -1,0 +1,15 @@
+package common
+
+import (
+    "errors"
+    "net/url"
+)
+
+type URI interface {
+    IsMatch(url.URL) (bool, error)
+}
+
+var (
+    ErrServerURIMisconfigured error = errors.New("Misconfigured ServerURI")
+    ErrPathURIMisconfigured error = errors.New("Misconfigured PathURI")
+)

--- a/common/uri_path.go
+++ b/common/uri_path.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+    "fmt"
+    "net/url"
+    "regexp"
+
+    "github.com/TestInABox/gostackinabox/common/log"
+)
+
+// matches based on paths
+type  PathURI struct {
+    Method string
+    Path *regexp.Regexp
+}
+
+func (pu *PathURI) IsMatch(u url.URL) (result bool, err error) {
+    if pu.Path == nil || (len(pu.Path.String()) == 0) {
+        log.Printf("No path regex available to match %s against", u.String())
+        err = fmt.Errorf("%w, missing regular expression to match with", ErrPathURIMisconfigured)
+        return
+    }
+
+    // use the regex to match
+    result = pu.Path.MatchString(u.Path)
+    log.Printf("Attempting to match %s against %s... match: %t", u.String(), pu.Path.String(), result)
+    return
+}
+
+var _ URI = &PathURI{}

--- a/common/uri_path_test.go
+++ b/common/uri_path_test.go
@@ -1,0 +1,132 @@
+package common_test
+
+import (
+    "errors"
+    "net/url"
+    "regexp"
+    "testing"
+
+    "github.com/TestInABox/gostackinabox/common"
+)
+
+func Test_Common_PathURI(t *testing.T) {
+    type TestScenarioExpectParameters struct {
+        result bool
+        err    error
+    }
+
+    type TestScenarioParameters struct {
+        regexpValue string
+        checkURL url.URL
+
+        beginFn func(t *testing.T, pu *common.PathURI)
+        expectFn func(t *testing.T, tsep TestScenarioExpectParameters)
+    }
+
+    type TestScenario struct {
+        name string
+        setup func(t *testing.T) TestScenarioParameters
+    }
+
+    var TestScenarios = []TestScenario{
+        {
+            name: "invalid regex",
+            setup: func(t *testing.T) TestScenarioParameters {
+                return TestScenarioParameters{
+                    checkURL:  url.URL{},
+                    beginFn: func(t *testing.T, pu *common.PathURI) {
+                        pu.Path = nil
+                    },
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.result {
+                            t.Errorf("Unexpectedly got result value of %t", tsep.result)
+                        }
+                        if !errors.Is(tsep.err, common.ErrPathURIMisconfigured) {
+                            t.Errorf(
+                                "Unexpected error result: %#v != %#v",
+                                tsep.err,
+                                common.ErrPathURIMisconfigured,
+                            )
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "valid regex invalid value",
+            setup: func(t *testing.T) TestScenarioParameters {
+                return TestScenarioParameters{
+                    checkURL:  url.URL{},
+                    beginFn: func(t *testing.T, pu *common.PathURI) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.result {
+                            t.Errorf("Unexpectedly got result value of %t", tsep.result)
+                        }
+                        if !errors.Is(tsep.err, common.ErrPathURIMisconfigured) {
+                            t.Errorf(
+                                "Unexpected error result: %#v != %#v",
+                                tsep.err,
+                                common.ErrPathURIMisconfigured,
+                            )
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "valid",
+            setup: func(t *testing.T) TestScenarioParameters {
+                uv, _ := url.Parse("http://example.com/hello")
+                return TestScenarioParameters{
+                    checkURL:  *uv,
+                    regexpValue: "^/hello",
+                    beginFn: func(t *testing.T, pu *common.PathURI) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if !tsep.result {
+                            t.Errorf("Unexpectedly got result value of %t", tsep.result)
+                        }
+                        if tsep.err != nil {
+                            t.Errorf(
+                                "Unexpected error result: %#v",
+                                tsep.err,
+                            )
+                        }
+                    },
+                }
+            },
+        },
+    }
+
+    for _, scenario := range TestScenarios {
+        t.Run(
+            scenario.name,
+            func(t *testing.T) {
+                parameters := scenario.setup(t)
+
+                regex := regexp.MustCompile(parameters.regexpValue)
+                pathURI := &common.PathURI{
+                    Path: regex,
+                }
+
+                parameters.beginFn(t, pathURI)
+
+                if pathURI.Path != nil {
+                    regexValue := pathURI.Path.String()
+                    t.Logf("Regex(length: %d): \"%s\"", len(regexValue), regexValue)
+                } else {
+                    t.Logf("Empty regex")
+                }
+
+                result, err := pathURI.IsMatch(parameters.checkURL)
+                parameters.expectFn(
+                    t,
+                    TestScenarioExpectParameters{
+                        result: result,
+                        err: err,
+                    },
+                )
+
+            },
+        )
+    }
+}

--- a/common/uri_server.go
+++ b/common/uri_server.go
@@ -1,0 +1,135 @@
+package common
+
+import (
+    "fmt"
+    "net/url"
+
+    "github.com/TestInABox/gostackinabox/common/log"
+)
+
+/*
+ * ServerURI is an interface for the basic aspect of matching the protocol://<server>:<port>
+ * portion of the URL on requests. The BasicServerURI implements the minimum to support this
+ * functionality along with a basic mapping to include the HTTP and HTTPS protocol<->port
+ * mappings so most cases are covered without adding extra dependencies.
+ * Advanced systems that use a multitude of ports and services might find it advantageous
+ * to use a difference implementation that utilizes /etc/services to map the ports and
+ * services. This package seeks to minimize the dependencies and thus the advanced
+ * functionality which would require either a substantive implementation or additional
+ * library is beyond its purview.
+ */
+type ServerURI interface {
+    URI
+
+    GetProtocol() string
+    GetHost() string
+    GetPort() string
+}
+
+// matches based on the protocol (scheme), server, port
+type BasicServerURI struct {
+    Protocol string
+    Host string
+    Port string
+}
+
+func (bsu *BasicServerURI) GetProtocol() string {
+    return bsu.Protocol
+}
+
+func (bsu *BasicServerURI) GetHost() string {
+    return bsu.Host
+}
+
+func (bsu *BasicServerURI) GetPort() string {
+    return bsu.Port
+}
+
+func (bsu *BasicServerURI) IsMatch(u url.URL) (result bool, err error) {
+    // A basic mapping of the protocol to port
+    basicPortMapping := map[string]string{
+        "http": "http:80",
+        "https": "http:443",
+    }
+    // A basic mapping of the port to protocol
+    basicProtocolMapping := map[string]string{
+        "80": "https:80",
+        "443": "http:443",
+    }
+
+    protocol := u.Scheme
+    host := u.Hostname()
+    port := u.Port()
+
+    if len(protocol) > 0 {
+        last_char := protocol[len(protocol)-1:]
+        if last_char == ":" {
+            protocol = protocol[:len(protocol)-1]
+        }
+    }
+    log.Printf("Extracted Protocol %s from %s", protocol, u.Scheme)
+    log.Printf("Extracted Host %s from %s", protocol, u.Hostname())
+    log.Printf("Extracted Port %s from %s", protocol, u.Port())
+
+    // if the host isn't configured then generate an error
+    if len(bsu.Host) == 0 {
+        log.Printf("Missing required parameter - Host")
+        err = fmt.Errorf("%w - missing host configuration", ErrServerURIMisconfigured)
+        return
+    }
+
+    // match the host first
+    if bsu.Host != host {
+        log.Printf("Host Mismatch: %s != %s", bsu.Host, host)
+        result = false
+        return
+    }
+
+    finalMapping := map[string]bool{
+        fmt.Sprintf("%s:%s", bsu.Protocol, bsu.Port): true,
+    }
+    log.Printf("Initial alternate mapping: %#v", finalMapping)
+    if entry, ok := basicPortMapping[bsu.Protocol]; ok {
+        finalMapping[entry] = true
+        log.Printf("Adding %s to the alternate mapping from Port Maps", entry)
+    }
+    if entry, ok := basicProtocolMapping[bsu.Port]; ok {
+        finalMapping[entry] = true
+        log.Printf("Adding %s to the alternate mapping from Protocol Maps", entry)
+    }
+
+    log.Printf("Alternate Mapping: %#v", finalMapping)
+
+    // first,  check the protocol-port mapping to see if it's in there
+    // if so, bypass the specific protocol-port checks
+    matchProtoAndPort := fmt.Sprintf("%s:%s", u.Scheme, port)
+    if _, ok := finalMapping[matchProtoAndPort]; !ok {
+        if len(bsu.Protocol) > 0 && bsu.Protocol != u.Scheme {
+            log.Printf("Protocol Mismatch: %s != %s", bsu.Protocol, u.Scheme)
+            result = false
+            return
+        }
+
+        // finally the port if it's specified
+        if len(bsu.Port) > 0 && (len(port) == 0 || bsu.Port != port) {
+            log.Printf("Port Mismatch: %s != %s", bsu.Port, port)
+            result = false
+            return
+        }
+    }
+
+    // nothing disqualified the match, approve it
+    matchUrl := host
+    if len(bsu.Protocol) > 0 {
+        matchUrl = fmt.Sprintf("%s://%s", bsu.Protocol, matchUrl)
+    }
+    if len(bsu.Port) > 0 {
+        matchUrl = fmt.Sprintf("%s:%s", matchUrl, bsu.Port)
+    }
+    log.Printf("Matched using %s on %s", matchUrl, u.String())
+    result = true
+    return
+}
+
+var _ ServerURI = &BasicServerURI{}
+var _ URI = &BasicServerURI{}

--- a/common/uri_server_test.go
+++ b/common/uri_server_test.go
@@ -1,0 +1,205 @@
+package common_test
+
+import (
+    "errors"
+    "net/url"
+    "testing"
+
+    "github.com/TestInABox/gostackinabox/common"
+)
+
+func Test_Common_BasicServerURI(t *testing.T) {
+    type TestScenarioExpectParameters struct {
+        result bool
+        err    error
+    }
+
+    type TestScenarioParameters struct {
+        checkURL url.URL
+
+        beginFn func(t *testing.T, su *common.BasicServerURI)
+        expectFn func(t *testing.T, tsep TestScenarioExpectParameters)
+    }
+
+    type TestScenario struct {
+        name string
+        setup func(t *testing.T) TestScenarioParameters
+    }
+
+    var TestScenarios = []TestScenario{
+        {
+            name: "invalid hostname",
+            setup: func(t *testing.T) TestScenarioParameters {
+                return TestScenarioParameters{
+                    checkURL: url.URL{},
+                    beginFn: func(t *testing.T, su *common.BasicServerURI) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.result {
+                            t.Errorf("Unexpectedly got result value of %t", tsep.result)
+                        }
+                        if !errors.Is(tsep.err, common.ErrServerURIMisconfigured) {
+                            t.Errorf(
+                                "Unexpected error result: %#v != %#v",
+                                tsep.err,
+                                common.ErrServerURIMisconfigured,
+                            )
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "hostname mismatch",
+            setup: func(t *testing.T) TestScenarioParameters {
+                return TestScenarioParameters{
+                    checkURL: url.URL{
+                        Host: "example.com",
+                    },
+                    beginFn: func(t *testing.T, su *common.BasicServerURI) {
+                        su.Host = "com.example"
+                    },
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.result {
+                            t.Errorf("Unexpectedly got result value of %t", tsep.result)
+                        }
+                        if tsep.err != nil {
+                            t.Errorf(
+                                "Unexpected error result: %#v",
+                                tsep.err,
+                            )
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "protocol mismatch",
+            setup: func(t *testing.T) TestScenarioParameters {
+                return TestScenarioParameters{
+                    checkURL: url.URL{
+                        Scheme: "https",
+                        Host: "example.com",
+                    },
+                    beginFn: func(t *testing.T, su *common.BasicServerURI) {
+                        su.Host = "example.com"
+                        su.Protocol = "http"
+                    },
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.result {
+                            t.Errorf("Unexpectedly got result value of %t", tsep.result)
+                        }
+                        if tsep.err != nil {
+                            t.Errorf(
+                                "Unexpected error result: %#v",
+                                tsep.err,
+                            )
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "protocol mismatch with colon",
+            setup: func(t *testing.T) TestScenarioParameters {
+                return TestScenarioParameters{
+                    checkURL: url.URL{
+                        Scheme: "https:",
+                        Host: "example.com",
+                    },
+                    beginFn: func(t *testing.T, su *common.BasicServerURI) {
+                        su.Host = "example.com"
+                        su.Protocol = "http"
+                    },
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.result {
+                            t.Errorf("Unexpectedly got result value of %t", tsep.result)
+                        }
+                        if tsep.err != nil {
+                            t.Errorf(
+                                "Unexpected error result: %#v",
+                                tsep.err,
+                            )
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "port mismatch",
+            setup: func(t *testing.T) TestScenarioParameters {
+                return TestScenarioParameters{
+                    checkURL: url.URL{
+                        Scheme: "http",
+                        Host: "example.com:443",
+                    },
+                    beginFn: func(t *testing.T, su *common.BasicServerURI) {
+                        su.Host = "example.com"
+                        su.Protocol = "http"
+                        su.Port = "80"
+                    },
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.result {
+                            t.Errorf("Unexpectedly got result value of %t", tsep.result)
+                        }
+                        if tsep.err != nil {
+                            t.Errorf(
+                                "Unexpected error result: %#v",
+                                tsep.err,
+                            )
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "success",
+            setup: func(t *testing.T) TestScenarioParameters {
+                return TestScenarioParameters{
+                    checkURL: url.URL{
+                        Scheme: "http",
+                        Host: "example.com:443",
+                    },
+                    beginFn: func(t *testing.T, su *common.BasicServerURI) {
+                        su.Host = "example.com"
+                        su.Protocol = "http"
+                        su.Port = "443"
+                    },
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if !tsep.result {
+                            t.Errorf("Unexpectedly got result value of %t", tsep.result)
+                        }
+                        if tsep.err != nil {
+                            t.Errorf(
+                                "Unexpected error result: %#v",
+                                tsep.err,
+                            )
+                        }
+                    },
+                }
+            },
+        },
+    }
+
+    for _, scenario := range TestScenarios {
+        t.Run(
+            scenario.name,
+            func(t *testing.T) {
+                parameters := scenario.setup(t)
+
+                serverURI := &common.BasicServerURI{}
+
+                parameters.beginFn(t, serverURI)
+
+                result, err := serverURI.IsMatch(parameters.checkURL)
+                parameters.expectFn(
+                    t,
+                    TestScenarioExpectParameters{
+                        result: result,
+                        err: err,
+                    },
+                )
+
+            },
+        )
+    }
+}

--- a/common/verbs.go
+++ b/common/verbs.go
@@ -1,0 +1,19 @@
+package common
+
+type HttpVerb string
+
+const (
+    HttpVerb_Connect HttpVerb = "CONNECT"
+    HttpVerb_Delete  HttpVerb = "DELETE"
+    HttpVerb_Get     HttpVerb = "GET"
+    HttpVerb_Head    HttpVerb = "HEAD"
+    HttpVerb_Option  HttpVerb = "OPTION"
+    HttpVerb_Patch   HttpVerb = "PATCH"
+    HttpVerb_Post    HttpVerb = "POST"
+    HttpVerb_Put     HttpVerb = "PUT"
+    HttpVerb_Trace   HttpVerb = "TRACE"
+)
+
+func GetHttpVerb(verb string) HttpVerb {
+    return HttpVerb(verb)
+}

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -1,0 +1,1 @@
+package example

--- a/examples/hello/helloworld.go
+++ b/examples/hello/helloworld.go
@@ -1,0 +1,77 @@
+package hello
+
+import (
+    "net/http"
+
+    "github.com/TestInABox/gostackinabox/common"
+    "github.com/TestInABox/gostackinabox/common/log"
+    "github.com/TestInABox/gostackinabox/service"
+    "github.com/TestInABox/gostackinabox/util"
+)
+
+
+/*
+ * HelloWorldService is a little more complex than HelloWorldBasic
+ * where it shows how to allow the single level to handle all the
+ * different HTTP verbs through mapping specific methods to any
+ * given HTTP verb.
+ *
+ * Do note that the system is not limited to just the HTTP verbs
+ * that are defined by the IETF HTTP related RFCs.
+ */
+type HelloWorldService struct {
+    service.ServiceHandler
+}
+
+func NewHelloWorldService() (s service.Service, err error) {
+     log.Printf("Creating a Hello World Service")
+     hw := &HelloWorldService{}
+     err = hw.Init(
+        "helloWorld",
+        &common.BasicServerURI{
+            Protocol: "https",
+            Host: "hello.world",
+            Port: "",
+        },
+    )
+     if err == nil {
+        err = hw.RegisterMethodHandler(common.HttpVerb_Get, common.HttpHandler(hw.MyGetHandler))
+        if err == nil {
+            err = hw.RegisterMethodHandler(common.HttpVerb_Head, common.HttpHandler(hw.MyHeadHandler))
+            if err != nil {
+                log.Printf("Failed to register HEAD handler: %#v", err)
+            }
+        }else {
+            log.Printf("Failed to registered GET handler: %#v", err)
+        }
+     } else {
+        log.Printf("Failed to initialize service: %#v", err)
+     }
+     s = hw
+     return
+}
+
+func (hw *HelloWorldService) MyGetHandler(request *common.HttpCall) (result *common.HttpReply, err error) {
+    log.Printf("Hello World Service GET Handler")
+    msg := "hello world!"
+    expectedLength := int64(len(msg))
+    result = &common.HttpReply{
+        Status: common.GetHttpStatus(200),
+        ResponseData: util.StringToResponseBody(msg),
+        Length: expectedLength,
+    }
+    return
+}
+
+func (hw *HelloWorldService) MyHeadHandler(request *common.HttpCall) (result *common.HttpReply, err error) {
+    log.Printf("Hello World Service HEAD Handler")
+    msg := "hello world!"
+    result = &common.HttpReply{
+        Status: common.GetHttpStatus(200),
+        Headers: make(http.Header),
+    }
+    result.Headers["x-msg"] = []string{msg}
+    return
+}
+
+var _ service.Service = &HelloWorldService{}

--- a/examples/hello/helloworld_basic.go
+++ b/examples/hello/helloworld_basic.go
@@ -1,0 +1,49 @@
+package hello
+
+import (
+    "github.com/TestInABox/gostackinabox/common"
+    "github.com/TestInABox/gostackinabox/common/log"
+    "github.com/TestInABox/gostackinabox/service"
+    "github.com/TestInABox/gostackinabox/util"
+)
+
+
+/*
+ * HelloWorldBasicService is the most basic handler implementation where
+ * everything is served via the singular method assigned to FuncHandler
+ * on the object.
+ */
+type HelloWorldBasicService struct {
+    service.ServiceHandler
+}
+
+func NewHelloWorldBasicService() (s service.Service, err error) {
+     hwb := &HelloWorldBasicService{}
+     err = hwb.Init(
+        "helloWorldBasic",
+        &common.BasicServerURI{
+            Protocol: "https",
+            Host: "hello.world",
+            Port: "",
+        },
+    )
+     if err != nil {
+        hwb.FuncHandler = hwb.HelloWorldHandler
+     }
+     s = hwb
+     return
+}
+
+func (hwb *HelloWorldBasicService) HelloWorldHandler(request *common.HttpCall) (result *common.HttpReply, err error) {
+    log.Printf("Hello World Basic Service FuncHandler")
+    msg := "hello world!"
+    expectedLength := int64(len(msg))
+    result = &common.HttpReply{
+        Status: common.GetHttpStatus(200),
+        ResponseData: util.StringToResponseBody(msg),
+        Length: expectedLength,
+    }
+    return
+}
+
+var _ service.Service = &HelloWorldBasicService{}

--- a/examples/hello/helloworld_test.go
+++ b/examples/hello/helloworld_test.go
@@ -1,0 +1,143 @@
+package hello_test
+
+import (
+    "errors"
+    "net/http"
+    "io"
+    "testing"
+
+    "github.com/TestInABox/gostackinabox/examples/hello"
+    "github.com/TestInABox/gostackinabox/router"
+)
+
+func Test_HelloWorldService(t *testing.T) {
+    t.Run(
+        "GET",
+        func(t *testing.T) {
+            // configure the HTTP Client
+            r := router.New()
+            http.DefaultClient.Transport = r
+
+            // create a Go-Stack-In-A-Box service
+            hwService, hwServiceErr := hello.NewHelloWorldService()
+            if hwServiceErr != nil {
+                t.Errorf("Failed to create hello World Service: %#v", hwServiceErr)
+            }
+
+            // expected result
+            expectedBody := "hello world!"
+            expectedBodyLength := len(expectedBody)
+            expectedStatusCode := 200
+
+            // register it with the client
+            serviceUrl := "https://hello.world"
+            registerErr := r.RegisterService(serviceUrl, hwService)
+            if registerErr != nil {
+                t.Errorf("Failed to register hello world service: %#v", registerErr)
+            }
+
+            // attempt the service call
+            resp, respErr := http.Get(serviceUrl)
+            if respErr != nil {
+                t.Errorf("Error making HTTP Call: %#v", respErr)
+            }
+            if resp != nil {
+                // validate the status code response
+                if resp.StatusCode != expectedStatusCode {
+                    t.Errorf("Unexpected status code: %d != %d", resp.StatusCode, expectedStatusCode)
+                }
+                // validate the body length
+                if resp.ContentLength != int64(expectedBodyLength) {
+                    t.Errorf("Unexpected body length: %d != %d", resp.ContentLength, expectedBodyLength)
+                }
+
+                // access the response body and validate it
+                bodyData := make([]byte, 2*expectedBodyLength)
+                readDataLength, readDataErr := resp.Body.Read(bodyData)
+                if readDataErr != nil {
+                    t.Errorf("Unexpected error reading data: %#v", readDataErr)
+                }
+                t.Logf("Data Length: %d, Data: %#v", readDataLength, bodyData)
+                if readDataLength != expectedBodyLength {
+                    t.Errorf("Unexpected data length read: %d != %d", readDataLength, expectedBodyLength)
+                }
+
+                // read gives back a byte array, to it must be converted to a string to convert
+                strBodyData := string(bodyData[:readDataLength])
+                if strBodyData != expectedBody {
+                    t.Errorf("Unexpected body data received: \"%s\" != \"%s\"", strBodyData, expectedBody)
+                }
+            } else {
+                t.Errorf("Unexpected nil response")
+            }
+        },
+    )
+    t.Run(
+        "HEAD",
+        func(t *testing.T) {
+            // configure the HTTP Client
+            r := router.New()
+            http.DefaultClient.Transport = r
+
+            // create a Go-Stack-In-A-Box service
+            hwService, hwServiceErr := hello.NewHelloWorldService()
+            if hwServiceErr != nil {
+                t.Errorf("Failed to create hello World Service: %#v", hwServiceErr)
+            }
+
+            // expected result
+            expectedHeaders := []string{"hello world!"}
+            expectedStatusCode := 200
+            // HEAD does not have a response body
+            expectedBodyLength := 0
+
+            // register it with the client
+            serviceUrl := "https://hello.world"
+            registerErr := r.RegisterService(serviceUrl, hwService)
+            if registerErr != nil {
+                t.Errorf("Failed to register hello world service: %#v", registerErr)
+            }
+
+            // attempt the service call
+            resp, respErr := http.Head(serviceUrl)
+            if respErr != nil {
+                t.Errorf("Error making HTTP Call: %#v", respErr)
+            }
+            if resp != nil {
+                // validate the status code response
+                if resp.StatusCode != expectedStatusCode {
+                    t.Errorf("Unexpected status code: %d != %d", resp.StatusCode, expectedStatusCode)
+                }
+                // validate the body length
+                if resp.ContentLength != int64(expectedBodyLength) {
+                    t.Errorf("Unexpected body length: %d != %d", resp.ContentLength, expectedBodyLength)
+                }
+
+                // access the response body and validate it
+                var bodyData []byte
+                readDataLength, readDataErr := resp.Body.Read(bodyData)
+                if !errors.Is(readDataErr, io.EOF) {
+                    t.Errorf("Unexpected error reading data: %#v", readDataErr)
+                }
+                if readDataLength != expectedBodyLength {
+                    t.Errorf("Unexpected data length read: %d != %d", readDataLength, expectedBodyLength)
+                }
+
+                // read gives back a byte array, to it must be converted to a string to convert
+                if strHeaderData, ok := resp.Header["x-msg"]; ok {
+                    if len(strHeaderData) != len(expectedHeaders) {
+                        t.Errorf("Header field length does not match: %d != %d", len(strHeaderData), len(expectedHeaders))
+                    } else {
+                        if strHeaderData[0] != expectedHeaders[0] {
+                            t.Errorf("Unexpected body data received: \"%s\" != \"%s\"", strHeaderData[9], expectedHeaders[0])
+                        }
+                    }
+                } else {
+                    t.Errorf("Missing headers for `x-msg`")
+                }
+            } else {
+                t.Errorf("Unexpected Nil response")
+            }
+        },
+    )
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/TestInABox/gostackinabox
+
+go 1.18

--- a/router/README.rst
+++ b/router/README.rst
@@ -1,0 +1,13 @@
+******
+Router
+******
+
+This implements the Golang net.http.RoundTripper interface in order to
+achieve the HTTP Request Interception, and then redirecting to
+various services implementing the desired APIs.
+
+Where the Python version of StackInABox allowed for different interceptor
+libraries the Golang version provides its own, in part due to the fact that
+there are no interceptor libraries in Golang like there are in Python; but
+also due to the ease of which Golang enables the interception using a
+standardized interface provided directly by Golang.

--- a/router/error.go
+++ b/router/error.go
@@ -1,0 +1,11 @@
+package router
+
+import (
+    "errors"
+)
+
+var (
+    ErrResponseBuildingInternalError error = errors.New("Service Router: Internal Error while building response")
+    ErrServiceHandlerAlreadyRegister error = errors.New("Service Router: Already Registered")
+    ErrInvalidRequest error = errors.New("Service Router: Invalid Request")
+)

--- a/router/router.go
+++ b/router/router.go
@@ -1,0 +1,187 @@
+package router
+
+import (
+    "fmt"
+    "net/http"
+
+    "github.com/TestInABox/gostackinabox/common"
+    "github.com/TestInABox/gostackinabox/common/log"
+    "github.com/TestInABox/gostackinabox/service"
+    "github.com/TestInABox/gostackinabox/util"
+)
+
+type Router struct {
+    ProtoMajor int
+    ProtoMinor int
+    RequestHandlers service.ServiceHandlerMap // TODO: Update
+    DisableCompression bool
+}
+
+func New() *Router {
+    return &Router{
+        ProtoMajor: 1,
+        ProtoMinor: 1,
+        RequestHandlers: make(service.ServiceHandlerMap),
+        DisableCompression: true, // compression isn't handled by this transport router
+    }
+}
+
+// service name is the scheme + host and optionally the port portion of a URL
+func (irt *Router) RegisterService(service string, handler service.Service) (err error) {
+    log.Printf("Attempting to register service %s with handler %v", service, handler)
+    if existing, ok := irt.RequestHandlers[service]; ok {
+        log.Printf("Service %s already registered using handler %v", service, existing)
+        err = fmt.Errorf("%w: Service %s already registered", ErrServiceHandlerAlreadyRegister, service)
+        return
+    }
+    log.Printf("Accepting registration of service %s using handler %v", service, handler)
+
+    irt.RequestHandlers[service] = handler
+    return
+}
+
+func (irt *Router) BuildResponse(reply *common.HttpReply, request *http.Request) (response *http.Response, err error) {
+    if reply == nil || request == nil {
+        log.Printf("Recieved invalid parameter: Reply: %v, Request: %#v", reply, request)
+        err = fmt.Errorf(
+            "%w: Invalid service response or systems error (reply: %#v, request: %#v",
+            ErrResponseBuildingInternalError,
+            reply,
+            request,
+        )
+        return
+    }
+
+    log.Printf("Building Reply: Status: %d, Data Length: %d", reply.Status, reply.Length)
+
+    intStatus := int(reply.Status)
+    response = &http.Response{
+        Status: fmt.Sprintf("%d", intStatus),
+        StatusCode: intStatus,
+        Proto: fmt.Sprintf("HTTP/%d.%d", irt.ProtoMajor, irt.ProtoMinor),
+        ProtoMajor: irt.ProtoMajor,
+        ProtoMinor: irt.ProtoMinor,
+        Header: reply.Headers,
+        Body: reply.ResponseData,
+        ContentLength: reply.Length,
+        Trailer: reply.Trailers,
+        Request: request,
+        Uncompressed: false, // this doesn't do anything with compression
+        TLS: nil,  // this doesn't implement TLS at all; it's all unencrypted
+    }
+    return
+}
+
+func (irt *Router) ServiceRouter(request *http.Request) (response *http.Response, err error) {
+    // 1. build a response object
+    // 2. call into a handler method providing the request and response
+
+    // Reservered Errors:
+    //  405: Method Not Supported
+    //      URI handled but HTTP Method is not
+    //  595: Route Not Handled
+    //      http://127.0.0.1:80/uri is completely unhandled
+    //  596: Service Error
+    //      Service handling the request had an error
+    //  597: Service doesn't handle a sub-route
+    //      Service handles part of but not the entire route
+    requestUrl := request.URL
+    if requestUrl == nil {
+        log.Printf("Request is invalid because the URL attribute is nil: %#v", request)
+        err = fmt.Errorf("%w: Request has a nil URL", ErrInvalidRequest)
+        return
+    }
+    // Normally it's an error to set these; however we need to set them for the stack to work properly
+    if len(request.RequestURI) == 0 {
+        request.RequestURI = "/"
+    }
+    if len(request.URL.Path) == 0 {
+        request.URL.Path = "/"
+        request.URL.RawPath = "/"
+    }
+
+
+    log.Printf("Attempting to handle request: Method: %s RequestURI: \"%s\"", request.Method, request.RequestURI)
+    // is there a handler for the URI?
+    for serviceName, serviceHandler := range irt.RequestHandlers {
+        log.Printf("Attempting to match Service %s against URL \"%s\"", serviceName, request.RequestURI)
+        // see if this service handles the URL
+        matcher := serviceHandler.GetMatcher()
+        matchResult, matchErr := matcher.IsMatch(*requestUrl)
+        if matchErr != nil {
+            // there's a problem with the matcher, test infrastructure needs to be fixed
+            log.Printf("Matcher for Service %s generated an error. Please fix the fixture: %#v", serviceName, matchErr)
+            err = fmt.Errorf("Service %s generated an error: %w", serviceName, matchErr)
+            return
+        }
+        if matchResult {
+            log.Printf("Service %s handles URI %s", serviceName, request.RequestURI)
+            // get the handler for the service
+            handler, handlerErr := serviceHandler.GetHandler(*requestUrl)
+            if handlerErr != nil {
+                log.Printf("Service %s generated an error when retrieving the handler: %#v", serviceName, handlerErr)
+                err = handlerErr
+                return
+            }
+
+            log.Printf("Running handler for Service %s on URI %s", serviceName, request.RequestURI)
+            // attempt to let the registered service handle it
+            reply, err := handler(
+                &common.HttpCall{
+                    Method: common.HttpVerb(request.Method),
+                    Url: request.URL,
+                    Headers: request.Header,
+                    Request: request,
+                },
+            )
+
+            // service had an error
+            if err != nil {
+                log.Printf("Service %s generated an error while handling the request: %#v", serviceName, err)
+                msg := fmt.Sprintf(
+                    "gostackinabox: service handling request had an error - %#v",
+                    err,
+                )
+                return irt.BuildResponse(
+                    &common.HttpReply{
+                        Status: common.HttpStatus_ServiceError,
+                        ResponseData: util.StringToResponseBody(msg),
+                        Length: int64(len(msg)),
+                    },
+                    request,
+                )
+            }
+
+            log.Printf("Service %s generated a successful response", serviceName)
+            // send back the reply from the service
+            return irt.BuildResponse(reply, request)
+        }
+    }
+
+    // return 595
+    msg := fmt.Sprintf(
+        "gostackinabox: no service to handle URL '%s'",
+        request.URL.String(),
+    )
+    return irt.BuildResponse(
+        &common.HttpReply{
+            Status: common.HttpStatus_RouteNotHandled,
+            ResponseData: util.StringToResponseBody(msg),
+            Length: int64(len(msg)),
+        },
+        request,
+    )
+}
+
+func (irt *Router) RoundTrip(request *http.Request) (response *http.Response, err error) {
+    log.Printf("Request Intercepted: %#v", request)
+    log.Printf("Request URL: %#v", request.URL)
+    log.Printf("Request URL: %#v", request.RequestURI)
+    response, err = irt.ServiceRouter(request)
+    log.Printf("Response Returned: %#v", response)
+    log.Printf("Error Returned: %#v", err)
+    return
+}
+
+// validate the interface
+var _ http.RoundTripper = &Router{}

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1,0 +1,521 @@
+package router_test
+
+import (
+    "errors"
+    "fmt"
+    "io"
+    "net/http"
+    "net/url"
+    "testing"
+
+    "github.com/TestInABox/gostackinabox/common"
+    "github.com/TestInABox/gostackinabox/router"
+    "github.com/TestInABox/gostackinabox/service"
+    "github.com/TestInABox/gostackinabox/util"
+)
+
+
+func validateStatus(t *testing.T, expectedStatus int, response *http.Response) {
+    strStatus := fmt.Sprintf("%d", expectedStatus)
+
+    if response.StatusCode != expectedStatus {
+        t.Errorf(
+            "Response Status Code (%d) does not match submitted status code (%d)",
+            response.StatusCode,
+            expectedStatus,
+        )
+    }
+    if response.Status != strStatus {
+        t.Errorf(
+            "Response Status (%s) does not match submitted status string (%s)",
+            response.Status,
+            strStatus,
+        )
+    }
+}
+
+func validateResponseBody(t *testing.T, expectedBody string, body io.ReadCloser) {
+    // bodyData is array that is larger than the expected data read
+    // so that it will actually receive data. Read() will not allocate
+    // an appropriate buffer to receive the data so this must be done instead
+    expectedLength := len(expectedBody)
+    bodyData := make([]byte, 2*expectedLength)
+    readLength, readErr := body.Read(bodyData)
+    if readErr != nil {
+        t.Errorf("Unexpectedly received a read error: %v", readErr)
+    }
+    if readLength != expectedLength {
+        t.Errorf("Unexpected data amount read: %d != %d", readLength, expectedLength)
+    }
+    strBodyData := string(bodyData[:expectedLength])
+    if strBodyData != expectedBody {
+        t.Errorf("Body data doesn't match: %s != %s", strBodyData, expectedBody)
+    }
+}
+
+func Test_Router_Router(t *testing.T) {
+    t.Run(
+        "New",
+        func(t *testing.T) {
+            irt := router.New()
+            if irt == nil {
+                t.Errorf("New generated a nil pointer")
+            }
+            if irt.RequestHandlers == nil {
+                t.Errorf("New did not create the route table")
+            }
+            if len(irt.RequestHandlers) != 0 {
+                t.Errorf("New did not generate an empty route table: %#v", irt.RequestHandlers)
+            }
+            expectedProtoMajor := 1
+            expectedProtoMinor := 1
+            expectedDisableCompression := true
+            if irt.ProtoMajor != expectedProtoMajor ||
+               irt.ProtoMinor != expectedProtoMinor ||
+               irt.DisableCompression != expectedDisableCompression {
+                t.Errorf(
+                    "Unexpected parameters: ProtoMajor: %d != %d, ProtoMinor: %d != %d, DisableCompression: %t != %t",
+                    irt.ProtoMajor,
+                    expectedProtoMajor,
+                    irt.ProtoMinor,
+                    expectedProtoMinor,
+                    irt.DisableCompression,
+                    expectedDisableCompression,
+                )
+            }
+        },
+    )
+    t.Run(
+        "RegisterService",
+        func(t *testing.T) {
+            irt := router.New()
+            if len(irt.RequestHandlers) != 0 {
+                t.Errorf("Not starting with an empty route table: %#v", irt.RequestHandlers)
+            }
+
+            serviceName := "dummyService"
+            serviceHandler := &service.ServiceHandler{}
+
+            err := irt.RegisterService(serviceName, serviceHandler)
+            if err != nil {
+                t.Errorf("Unexpected error adding service name (%v) to the route table: %v - %#v", serviceName, err, irt.RequestHandlers)
+            }
+
+            // adding another time should generate an error
+            err = irt.RegisterService(serviceName, serviceHandler)
+            if !errors.Is(err, router.ErrServiceHandlerAlreadyRegister) {
+                t.Errorf("Unexpected error adding a suplicate service name (%v) to the route table: %v - %#v", serviceName, err, irt.RequestHandlers)
+            }
+        },
+    )
+    t.Run(
+        "BuildResponse",
+        func(t *testing.T) {
+            type TestScenarioExpectParameters struct {
+                router   *router.Router
+                response *http.Response
+                err      error
+            }
+
+            type TestScenarioParameters struct {
+                request *http.Request
+                response *common.HttpReply
+                beginFn func(t *testing.T)
+                expectFn func(t *testing.T, tsep TestScenarioExpectParameters)
+            }
+
+            type TestScenario struct {
+                name string
+                setup func(t *testing.T) TestScenarioParameters
+            }
+
+            var TestScenarios = []TestScenario{
+                {
+                    name: "Nil response",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        return TestScenarioParameters{
+                            request: nil,
+                            response: nil,
+                            beginFn: func(t *testing.T) {},
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if !errors.Is(tsep.err, router.ErrResponseBuildingInternalError) {
+                                    t.Errorf("Unexpected error for build response: %v != %v", tsep.err, router.ErrResponseBuildingInternalError)
+                                }
+                                if tsep.response != nil {
+                                    t.Errorf("Unexpected HttpReply received: %#v", tsep.response)
+                                }
+                            },
+                        }
+                    },
+                },
+                {
+                    name: "Nil request",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        return TestScenarioParameters{
+                            request: nil,
+                            response: &common.HttpReply{},
+                            beginFn: func(t *testing.T) {},
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if !errors.Is(tsep.err, router.ErrResponseBuildingInternalError) {
+                                    t.Errorf("Unexpected error for build response: %v != %v", tsep.err, router.ErrResponseBuildingInternalError)
+                                }
+                                if tsep.response != nil {
+                                    t.Errorf("Unexpected HttpReply received: %#v", tsep.response)
+                                }
+                            },
+                        }
+                    },
+                },
+                {
+                    name: "valid",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        header := make(http.Header)
+                        trailer := make(http.Header)
+                        status := 200
+                        msg := "the quick brown fox jumped over the hen house to escape the farmer"
+                        expectedLength := int64(len(msg))
+                        return TestScenarioParameters{
+                            request: &http.Request{},
+                            response: &common.HttpReply{
+                                Status: common.HttpStatusCode(status),
+                                Headers: header,
+                                Trailers: trailer,
+                                ResponseData: util.StringToResponseBody(msg),
+                                Length: expectedLength,
+                            },
+                            beginFn: func(t *testing.T) {},
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if tsep.err != nil {
+                                    t.Errorf("Unexpected error received: %v", tsep.err)
+                                }
+                                if tsep.response == nil {
+                                    t.Errorf("Unexpectedly did not receive an HttpReply: %#v", tsep.response)
+                                } else {
+                                    strProto := fmt.Sprintf(
+                                        "HTTP/%d.%d",
+                                        tsep.router.ProtoMajor,
+                                        tsep.router.ProtoMinor,
+                                    )
+                                    if tsep.response.Proto != strProto {
+                                        t.Errorf(
+                                            "Response Protocol (%s) does not match the expected protocol (%s)",
+                                            tsep.response.Proto,
+                                            strProto,
+                                        )
+                                    }
+                                    if tsep.response.ProtoMajor != tsep.router.ProtoMajor {
+                                        t.Errorf(
+                                            "Response Protocol Major Version (%d) does not match the expected protocol major version (%d)",
+                                            tsep.response.ProtoMajor,
+                                            tsep.router.ProtoMajor,
+                                        )
+                                    }
+                                    if tsep.response.ProtoMinor != tsep.router.ProtoMinor {
+                                        t.Errorf(
+                                            "Response Protocol Minor Version (%d) does not match the expected protocol minor version (%d)",
+                                            tsep.response.ProtoMinor,
+                                            tsep.router.ProtoMinor,
+                                        )
+                                    }
+                                    headerMatch, headerMatchErr := util.EqualHeaders(
+                                        &tsep.response.Header,
+                                        &header,
+                                    )
+                                    if headerMatch == false {
+                                        t.Errorf("%v", headerMatchErr)
+                                    }
+                                    trailerMatch, trailerMatchErr := util.EqualHeaders(
+                                        &tsep.response.Trailer,
+                                        &trailer,
+                                    )
+                                    if trailerMatch == false {
+                                        t.Errorf("%v", trailerMatchErr)
+                                    }
+                                    if tsep.response.ContentLength != expectedLength {
+                                        t.Errorf(
+                                            "Expected Body data length doesn't match: %d != %d",
+                                            tsep.response.ContentLength,
+                                            expectedLength,
+                                        )
+                                    }
+                                    if tsep.response.Uncompressed {
+                                        t.Errorf("Unexpectedly found compression enabled")
+                                    }
+                                    if tsep.response.TLS != nil {
+                                        t.Errorf("Unexpected found TLS support: %v", tsep.response.TLS)
+                                    }
+
+                                    validateStatus(t, status, tsep.response)
+                                    validateResponseBody(t, msg, tsep.response.Body)
+                                }
+                            },
+                        }
+                    },
+                },
+            }
+
+            for _, scenario := range TestScenarios {
+                t.Run(
+                    scenario.name,
+                    func(t *testing.T) {
+                        parameters := scenario.setup(t)
+
+                        parameters.beginFn(t)
+
+                        irt := router.New()
+                        hr, err := irt.BuildResponse(parameters.response, parameters.request)
+                        parameters.expectFn(
+                            t,
+                            TestScenarioExpectParameters{
+                                router: irt,
+                                response: hr,
+                                err: err,
+                            },
+                        )
+                    },
+                )
+            }
+        },
+    )
+    t.Run(
+        "RoundTrip",
+        func(t *testing.T) {
+            type TestScenarioExpectParameters struct {
+                router   *router.Router
+                response *http.Response
+                err      error
+            }
+
+            type TestScenarioParameters struct {
+                request *http.Request
+
+                beginFn func(t *testing.T, irt *router.Router)
+                expectFn func(t *testing.T, tsep TestScenarioExpectParameters)
+            }
+
+            type TestScenario struct {
+                name string
+                setup func(t *testing.T) TestScenarioParameters
+            }
+
+            var TestScenarios = []TestScenario{
+                {
+                    name: "invalid route",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        myUrl, _ := url.Parse("http://example.com/")
+                        return TestScenarioParameters{
+                            request: &http.Request{
+                                URL: myUrl,
+                            },
+                            beginFn: func(t *testing.T, irt *router.Router) {
+                            },
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if tsep.err != nil {
+                                    t.Errorf("Unexpectedly received an error: %#v", tsep.err)
+                                }
+                                if tsep.response == nil {
+                                    t.Errorf("Did not receive a response")
+                                } else {
+                                    msg := fmt.Sprintf(
+                                        "gostackinabox: no service to handle URL '%s'",
+                                        myUrl.String(),
+                                    )
+                                    validateStatus(t, int(common.HttpStatus_RouteNotHandled), tsep.response)
+                                    validateResponseBody(t, msg, tsep.response.Body)
+                                }
+                            },
+                        }
+                    },
+                },
+                {
+                    name: "invalid URL",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        myUrl, _ := url.Parse("http://example.com/")
+                        expectedErr := errors.New("mock service error")
+                        return TestScenarioParameters{
+                            request: &http.Request{},
+                            beginFn: func(t *testing.T, irt *router.Router) {
+                                serviceName := util.GetUrlBaseResource(myUrl)
+                                serviceHandler := &service.ServiceHandler{
+                                    Matcher: &common.BasicServerURI{
+                                        Protocol: "http",
+                                        Host: "example.com",
+                                    },
+                                    FuncHandler: func(hc *common.HttpCall) (hr *common.HttpReply, err error) {
+                                        err = expectedErr
+                                        return
+                                    },
+                                }
+
+                                err := irt.RegisterService(serviceName, serviceHandler)
+                                if err != nil {
+                                    t.Errorf("Unexpected error adding service name (%v) to the route table: %v - %#v", serviceName, err, irt.RequestHandlers)
+                                }
+                            },
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if !errors.Is(tsep.err, router.ErrInvalidRequest) {
+                                    t.Errorf("Unexpectedly received an error: %#v != %v", tsep.err, router.ErrInvalidRequest)
+                                }
+                                if tsep.response != nil {
+                                    t.Errorf("Unexpectedly received a response; %#v", tsep.response)
+                                }
+                            },
+                        }
+                    },
+                },
+                {
+                    name: "service match error",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        myUrl, _ := url.Parse("http://example.com/")
+                        expectedErr := errors.New("mock service error")
+                        return TestScenarioParameters{
+                            request: &http.Request{
+                                URL: myUrl,
+                            },
+                            beginFn: func(t *testing.T, irt *router.Router) {
+                                serviceName := util.GetUrlBaseResource(myUrl)
+                                serviceHandler := &service.ServiceHandler{
+                                    FuncHandler: func(hc *common.HttpCall) (hr *common.HttpReply, err error) {
+                                        err = expectedErr
+                                        return
+                                    },
+                                    Matcher: &common.BasicServerURI{
+                                        Protocol: "http",
+                                        Host: "",
+                                    },
+                                }
+
+                                err := irt.RegisterService(serviceName, serviceHandler)
+                                if err != nil {
+                                    t.Errorf("Unexpected error adding service name (%v) to the route table: %v - %#v", serviceName, err, irt.RequestHandlers)
+                                }
+                            },
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if !errors.Is(tsep.err, common.ErrServerURIMisconfigured) {
+                                    t.Errorf("Unexpectedly received an error: %#v != %#v", tsep.err, common.ErrServerURIMisconfigured)
+                                }
+                                if tsep.response != nil {
+                                    t.Errorf("Unexpectedly received a response: %#v", tsep.response)
+                                }
+                            },
+                        }
+                    },
+                },
+                {
+                    name: "service error",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        myUrl, _ := url.Parse("http://example.com/")
+                        expectedErr := errors.New("mock service error")
+                        return TestScenarioParameters{
+                            request: &http.Request{
+                                URL: myUrl,
+                            },
+                            beginFn: func(t *testing.T, irt *router.Router) {
+                                serviceName := util.GetUrlBaseResource(myUrl)
+                                serviceHandler := &service.ServiceHandler{
+                                    Matcher: &common.BasicServerURI{
+                                        Protocol: "http",
+                                        Host: "example.com",
+                                    },
+                                    FuncHandler: func(hc *common.HttpCall) (hr *common.HttpReply, err error) {
+                                        err = expectedErr
+                                        return
+                                    },
+                                }
+
+                                err := irt.RegisterService(serviceName, serviceHandler)
+                                if err != nil {
+                                    t.Errorf("Unexpected error adding service name (%v) to the route table: %v - %#v", serviceName, err, irt.RequestHandlers)
+                                }
+                            },
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if tsep.err != nil {
+                                    t.Errorf("Unexpectedly received an error: %#v", tsep.err)
+                                }
+                                if tsep.response == nil {
+                                    t.Errorf("Did not receive a response")
+                                } else {
+                                    msg := fmt.Sprintf(
+                                        "gostackinabox: service handling request had an error - %#v",
+                                        expectedErr,
+                                    )
+                                    validateStatus(t, int(common.HttpStatus_ServiceError), tsep.response)
+                                    validateResponseBody(t, msg, tsep.response.Body)
+                                }
+                            },
+                        }
+                    },
+                },
+                {
+                    name: "success",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        expectedStatus := 200
+                        msg := "hello world"
+                        myUrl, _ := url.Parse("http://example.com/")
+                        return TestScenarioParameters{
+                            request: &http.Request{
+                                URL: myUrl,
+                            },
+                            beginFn: func(t *testing.T, irt *router.Router) {
+                                serviceName := util.GetUrlBaseResource(myUrl)
+                                serviceHandler := &service.ServiceHandler{
+                                    Matcher: &common.BasicServerURI{
+                                        Protocol: "http",
+                                        Host: "example.com",
+                                    },
+                                    FuncHandler: func(hc *common.HttpCall) (hr *common.HttpReply, err error) {
+                                        hr = &common.HttpReply{
+                                            Status: common.HttpStatusCode(expectedStatus),
+                                            ResponseData: util.StringToResponseBody(msg),
+                                            Length: int64(len(msg)),
+                                        }
+                                        return
+                                    },
+                                }
+
+                                err := irt.RegisterService(serviceName, serviceHandler)
+                                if err != nil {
+                                    t.Errorf("Unexpected error adding service name (%v) to the route table: %v - %#v", serviceName, err, irt.RequestHandlers)
+                                }
+                            },
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if tsep.err != nil {
+                                    t.Errorf("Unexpectedly received an error: %#v", tsep.err)
+                                }
+                                if tsep.response == nil {
+                                    t.Errorf("Did not receive a response")
+                                } else {
+                                    validateStatus(t, expectedStatus, tsep.response)
+                                    validateResponseBody(t, msg, tsep.response.Body)
+                                }
+                            },
+                        }
+                    },
+                },
+            }
+
+            for _, scenario := range TestScenarios {
+                t.Run(
+                    scenario.name,
+                    func(t *testing.T) {
+                        parameters := scenario.setup(t)
+
+                        irt := router.New()
+
+                        parameters.beginFn(t, irt)
+
+                        req, err := irt.RoundTrip(parameters.request)
+                        parameters.expectFn(
+                            t,
+                            TestScenarioExpectParameters{
+                                router: irt,
+                                response: req,
+                                err: err,
+                            },
+                        )
+                    },
+                )
+            }
+        },
+    )
+}

--- a/service/requestmethodhandlermap.go
+++ b/service/requestmethodhandlermap.go
@@ -1,0 +1,27 @@
+package service
+
+import (
+    "fmt"
+)
+
+// map[request method]service
+type RequestMethodHandlerMap map[string]Service
+
+func (rmhm RequestMethodHandlerMap) AddHandler(method string, service Service) (err error) {
+    // the `method` isn't validated as it doesn't really matter, and leaving it
+    // unvalidated means we have a greater breadth of call support
+
+    if service == nil {
+        err = fmt.Errorf("%w: Cannot register a nil service", ErrInvalidService)
+        return
+    }
+
+    _, ok := rmhm[method]
+    if ok {
+        err = fmt.Errorf("%w: Method %s", ErrRequestHandlerAlreadyRegister, method)
+        return
+    }
+
+    rmhm[method] = service
+    return
+}

--- a/service/requestmethodhandlermap_test.go
+++ b/service/requestmethodhandlermap_test.go
@@ -1,0 +1,97 @@
+package service_test
+
+import (
+    "errors"
+    "testing"
+
+    "github.com/TestInABox/gostackinabox/service"
+)
+
+func TestRequestMethodHandlerMap(t *testing.T) {
+    type TestScenarioExpectParameters struct {
+        err error
+    }
+
+    type TestScenarioParameters struct {
+        value string
+        svc service.Service
+        beginFn func(t *testing.T, mapper *service.RequestMethodHandlerMap)
+        expectFn func(t *testing.T, tsep TestScenarioExpectParameters)
+    }
+
+    type TestScenario struct {
+        name string
+        setup func(t *testing.T) TestScenarioParameters
+    }
+
+    var TestScenarios = []TestScenario{
+        {
+            name: "Invalid service",
+            setup: func(t *testing.T) TestScenarioParameters {
+                return TestScenarioParameters{
+                    value: "no-matter-the-method",
+                    svc: nil,
+                    beginFn: func(t *testing.T, mapper *service.RequestMethodHandlerMap) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if !errors.Is(tsep.err, service.ErrInvalidService) {
+                            t.Errorf("Unexpected error received; %v != %v", tsep.err, service.ErrInvalidService)
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "Repeated service addition",
+            setup: func(t *testing.T) TestScenarioParameters {
+                methodValue := "bar"
+                return TestScenarioParameters{
+                    value: methodValue,
+                    svc: &service.ServiceHandler{},
+                    beginFn: func(t *testing.T, mapper *service.RequestMethodHandlerMap) {
+                        (*mapper)[methodValue] = &service.ServiceHandler{}
+                    },
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if !errors.Is(tsep.err, service.ErrRequestHandlerAlreadyRegister) {
+                            t.Errorf("Unexpected error received; %v != %v", tsep.err, service.ErrRequestHandlerAlreadyRegister)
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "Success",
+            setup: func(t *testing.T) TestScenarioParameters {
+                methodValue := "bar"
+                return TestScenarioParameters{
+                    value: methodValue,
+                    svc: &service.ServiceHandler{},
+                    beginFn: func(t *testing.T, mapper *service.RequestMethodHandlerMap) {
+                    },
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.err != nil {
+                            t.Errorf("Unexpected error received; %v", tsep.err)
+                        }
+                    },
+                }
+            },
+        },
+    }
+
+    for _, scenario := range TestScenarios {
+        t.Run(
+            scenario.name,
+            func(t *testing.T) {
+                mapper := service.RequestMethodHandlerMap{}
+
+                parameters := scenario.setup(t)
+
+                parameters.beginFn(t, &mapper)
+
+                results := TestScenarioExpectParameters{
+                    err: mapper.AddHandler(parameters.value, parameters.svc),
+                }
+                parameters.expectFn(t, results)
+            },
+        )
+    }
+}

--- a/service/service.go
+++ b/service/service.go
@@ -1,0 +1,233 @@
+package service
+
+import (
+    "fmt"
+    "net/url"
+
+    "github.com/TestInABox/gostackinabox/common"
+    "github.com/TestInABox/gostackinabox/common/log"
+    "github.com/TestInABox/gostackinabox/util"
+)
+
+/*
+    In the Python Stack-In-A-Box implementation a sub-service
+    was just another service; however, Python also had 3rd Party
+    tools for doing the initial intercept at the URL Domain Level.
+
+    The service handler here acts like the 3rd Party tools in Python
+    to capture the domain level (e.g the `https://example.com` portion
+    of `https://example.com/some/uri/path/object'.
+
+    Some basic services may wish to implement their entire stack using
+    just the ServiceHandler as a base. More advanced services will
+    want to combine it with a series of registered methods and Service
+    instances to offload and simplify the handling of complex URI paths.
+*/
+
+// a service must match at the URL Domain Level
+type ServiceHandler struct {
+    isSubService bool
+    Name string
+    Matcher common.URI
+    // handle the local verbs (e.g GET/POST/OPTION/etc on /)
+    FuncHandler common.HttpHandler
+    MethodMap   common.HttpHandlerMap
+    // handle sub-routes (e.g  GET/POST/OPTION/etc on /<object>)
+    //SubServices ServiceMethodHandlerMap
+    SubServices ServiceHandlerMap
+}
+
+func (sh *ServiceHandler) Init(name string, matcher common.URI) (err error) {
+    sh.Name = name
+    sh.Matcher = matcher
+    sh.MethodMap = make(common.HttpHandlerMap)
+    sh.SubServices = make(ServiceHandlerMap)
+    sh.FuncHandler =  sh.DefaultFuncHandler
+
+    switch sh.Matcher.(type) {
+    case common.ServerURI:
+        // only recognize the ServerURI matcher define the root state
+        sh.isSubService = false
+    default:
+        // all other matchers be subservices
+        sh.isSubService = true
+    }
+
+    return
+}
+
+func (sh *ServiceHandler) IsSubService() bool {
+    return sh.isSubService
+}
+
+func (sh *ServiceHandler) GetName() string {
+    return sh.Name
+}
+
+func (sh *ServiceHandler) GetMatcher() common.URI {
+    return sh.Matcher
+}
+
+func (sh *ServiceHandler) MethodHandler(request *common.HttpCall) (result *common.HttpReply, err error) {
+    for httpVerb, httpVerbHandler := range sh.MethodMap {
+        if request.Method == common.HttpVerb(httpVerb) {
+            result, err = httpVerbHandler(request)
+            return
+        }
+    }
+
+    msg := fmt.Sprintf("%s on %s is unhandled", request.Method, request.Url.String())
+    expectedLength := int64(len(msg))
+    result = &common.HttpReply{
+        Status: common.GetHttpStatus(405),
+        ResponseData: util.StringToResponseBody(msg),
+        Length: expectedLength,
+    }
+    return
+}
+
+func (sh *ServiceHandler) DefaultFuncHandler(request *common.HttpCall) (result *common.HttpReply, err error) {
+    msg := "Unhandled"
+    expectedLength := int64(len(msg))
+    result = &common.HttpReply{
+        Status: common.GetHttpStatus(500),
+        ResponseData: util.StringToResponseBody(msg),
+        Length: expectedLength,
+    }
+    return
+}
+
+func (sh *ServiceHandler) GetHandler(requestUrl url.URL) (result common.HttpHandler, err error) {
+    log.Printf("Checking if any handlers respond to %s", requestUrl.String())
+    // first is there any sub service that handles the route
+    for serviceName, serviceHandler := range sh.SubServices {
+        // see if this service handles the URL
+        matcher := serviceHandler.GetMatcher()
+        matchResult, matchErr := matcher.IsMatch(requestUrl)
+        if matchErr != nil {
+            // there's a problem with the matcher, test needs to be fixed
+            log.Printf("Retreiving matcher for service %s had error: %#v", serviceName, matchErr)
+            err = fmt.Errorf("Service %s generated an error: %w", serviceName, matchErr)
+            return
+        }
+        log.Printf("%s ? %#v : %t", serviceName, requestUrl, matchResult)
+        if matchResult {
+            // get the handler for the service
+            handler, handlerErr := serviceHandler.GetHandler(requestUrl)
+            if handlerErr != nil {
+                log.Printf("Retreiving handler for service %s had error: %#v", serviceName, handlerErr)
+                err = handlerErr
+                return
+            }
+
+            log.Printf("Service %s supports URI %s using handler %v", serviceName, requestUrl.String(), handler)
+            result = handler
+            return
+        }
+    }
+
+    log.Printf("No Subservices handling the URL %s", requestUrl.String())
+
+    log.Printf("Checking for method handlers (count: %d)", len(sh.MethodMap))
+    if len(sh.MethodMap) > 0 {
+        log.Printf("Using the Method Handler to handle the URL %s", requestUrl.String())
+        return sh.MethodHandler, nil
+    }
+
+    log.Printf("Using primary handler to handle the URL %s", requestUrl.String())
+    result = sh.FuncHandler
+    return
+}
+
+func (sh *ServiceHandler) ValidateRegex(r string, isSubService bool) (err error) {
+    // Regex:
+    //  1. starts with ^
+    //  2. if no subservices, then it must end is $
+    //  3. if there are subservices, then it may not end with a $
+    firstChar := r[0:1]
+    lastChar := r[len(r)-1:]
+    log.Printf("r: %s, first char: %s, last char: %s, subservice: %t", r, firstChar, lastChar, isSubService)
+
+    if firstChar != "^" {
+        log.Printf("RegEx Rule Violation: First Char (%s) is not ^", firstChar)
+        err = fmt.Errorf("%w: Regex must start with ^", ErrInvalidServiceRegex)
+        return
+    }
+
+    if lastChar != "$" &&  !isSubService {
+        log.Printf("RegEx Rule Violation (isSubService: %t): Last Char (%s) is not $ a", isSubService, firstChar)
+        err = fmt.Errorf("%w: Regex pattern must end with $", ErrInvalidServiceRegex)
+        return
+    }
+
+    if lastChar == "$" && isSubService {
+        log.Printf("RegEx Rule Violation (isSubService: %t): Last Char (%s) is $ a", isSubService, firstChar)
+        err = fmt.Errorf("%w: Subservice Regex must not end with $", ErrInvalidServiceRegex)
+        return
+    }
+
+    return
+}
+
+func (sh *ServiceHandler) RegisterHandler(subHandler Service) (err error) {
+    if subHandler == nil {
+        err = fmt.Errorf("%w: Missing Subservice instance", ErrInvalidService)
+        return
+    }
+
+    svcName := subHandler.GetName()
+
+    if len(svcName) == 0 {
+        err = fmt.Errorf("%w: Subservice must have a name", ErrInvalidService)
+        return
+    }
+
+    if !subHandler.IsSubService() {
+        err = fmt.Errorf("%w: Can only registere subservics", ErrInvalidService)
+        return
+    }
+
+    matcher := subHandler.GetMatcher()
+
+    switch m := matcher.(type) {
+    case common.ServerURI:
+        err = fmt.Errorf("%w: sub services cannot use `common.ServerURI` for their matcher", ErrInvalidService)
+        return
+    case *common.PathURI:
+        regExErr :=  sh.ValidateRegex(m.Path.String(), true)
+        if regExErr != nil {
+            err = fmt.Errorf("%w: Invalid regex for subservice", regExErr)
+            return
+        }
+    default:
+        // unable to validate regex
+    }
+
+    if _, ok := sh.SubServices[svcName]; ok {
+        // service is already registered
+        err = fmt.Errorf("%w: Attempting to register %s multiple times.", ErrServiceHandlerAlreadyRegister, svcName)
+        return
+    }
+
+    sh.SubServices[svcName] = subHandler
+    return
+}
+
+func (sh *ServiceHandler) RegisterMethodHandler(method common.HttpVerb, handler common.HttpHandler) (err error) {
+    if handler == nil {
+        err = fmt.Errorf("%w: Missing handler method for %s", ErrRequestHandlerInvalid, method)
+        return
+    }
+
+    if _, ok := sh.MethodMap[method]; ok {
+        // method is already registered
+        err = fmt.Errorf("%w: Attempting to register %s multiple times.", ErrRequestHandlerAlreadyRegister, method)
+        return
+    }
+    log.Printf("Registered method %s using handler %#v", method, handler)
+
+    sh.MethodMap[method] = handler
+    return
+}
+
+var _ Service = &ServiceHandler{}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1,0 +1,399 @@
+package service_test
+
+import (
+    "errors"
+    "fmt"
+    "net/url"
+    //"regexp"
+    "testing"
+
+    "github.com/TestInABox/gostackinabox/common"
+    "github.com/TestInABox/gostackinabox/service"
+)
+
+func TestService(t *testing.T) {
+    t.Run(
+        "init",
+        func(t *testing.T) {
+            handler := service.ServiceHandler{}
+            if handler.SubServices != nil {
+                t.Errorf("Unexpected initialized subservices: %v", handler.SubServices)
+            }
+            result := handler.Init("init", &common.BasicServerURI{})
+            if handler.SubServices == nil {
+                t.Errorf("Unexpectedly did not initialize the subservices: %v", handler.SubServices)
+            }
+            if result != nil {
+                t.Errorf("Unexpectedly received an error: %#v", result)
+            }
+        },
+    )
+    t.Run(
+        "GetMatcher",
+        func(t *testing.T) {
+            type TestScenarioExpectParameters struct {
+                matcher common.URI
+            }
+
+            type TestScenarioParameters struct {
+                beginFn func(t *testing.T, handler *service.ServiceHandler)
+                expectFn func(t *testing.T, tsep TestScenarioExpectParameters)
+            }
+
+            type TestScenario struct {
+                name string
+                setup func(t *testing.T) TestScenarioParameters
+            }
+
+            var TestScenarios = []TestScenario{
+                {
+                    name: "invalid matcher",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        return TestScenarioParameters{
+                            beginFn: func(t *testing.T, handler *service.ServiceHandler) {
+                                handler.Matcher = nil
+                            },
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if tsep.matcher != nil {
+                                    t.Errorf("Unexpectly received a matcher: %#v", tsep.matcher)
+                                }
+                            },
+                        }
+                    },
+                },
+                {
+                    name: "success",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        theMatcher := common.BasicServerURI{
+                            Protocol: "https",
+                            Host: "foo.bar",
+                            Port: "443",
+                        }
+                        return TestScenarioParameters{
+                            beginFn: func(t *testing.T, handler *service.ServiceHandler) {
+                                handler.Matcher = &theMatcher
+                            },
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if tsep.matcher.(*common.BasicServerURI).Protocol != theMatcher.Protocol ||
+                                   tsep.matcher.(*common.BasicServerURI).Host != theMatcher.Host ||
+                                   tsep.matcher.(*common.BasicServerURI).Port != theMatcher.Port {
+                                    t.Errorf("Unexpectly received a matcher: %#v", tsep.matcher)
+                                }
+                            },
+                        }
+                    },
+                },
+            }
+
+            for _, scenario := range TestScenarios {
+                t.Run(
+                    scenario.name,
+                    func(t *testing.T) {
+                        handler := service.ServiceHandler{}
+                        handler.Init(
+                            scenario.name,
+                            &common.BasicServerURI{},
+                        )
+
+                        parameters := scenario.setup(t)
+
+                        parameters.beginFn(t, &handler)
+
+                        results := TestScenarioExpectParameters{
+                            matcher: handler.GetMatcher(),
+                        }
+                        parameters.expectFn(t, results)
+                    },
+                )
+            }
+        },
+    )
+    t.Run(
+        "RegisterHandler",
+        func(t *testing.T) {
+            type TestScenarioExpectParameters struct {
+                err error
+            }
+
+            type TestScenarioParameters struct {
+                svc service.Service
+                beginFn func(t *testing.T, handler *service.ServiceHandler)
+                expectFn func(t *testing.T, tsep TestScenarioExpectParameters)
+            }
+
+            type TestScenario struct {
+                name string
+                setup func(t *testing.T) TestScenarioParameters
+            }
+
+            var TestScenarios = []TestScenario{
+                {
+                    name: "Invalid Service Instance",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        /*
+                        noImplementedSvc := &service.ServiceHandler{
+                            Name: "Not Implemented",
+                            Matcher: &common.BasicServerURI{
+                                Protocol: "http",
+                                Host: "example.com",
+                            },
+                        }
+                        */
+                        return TestScenarioParameters{
+                            //svc service.Service
+                            beginFn: func(t *testing.T, handler *service.ServiceHandler) {},
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if !errors.Is(tsep.err, service.ErrInvalidService) {
+                                    t.Errorf("Unexpected error received: %#v != %#v", tsep.err, service.ErrInvalidService)
+                                }
+                            },
+                        }
+                    },
+                },
+            }
+
+            for _, scenario := range TestScenarios {
+                t.Run(
+                    scenario.name,
+                    func(t *testing.T) {
+                        handler := service.ServiceHandler{}
+                        handler.Init(
+                            scenario.name,
+                            &common.BasicServerURI{
+                                Protocol: "http",
+                                Host: "example.com",
+                            },
+                        )
+
+                        parameters := scenario.setup(t)
+
+                        parameters.beginFn(t, &handler)
+
+                        results := TestScenarioExpectParameters{
+                            err: handler.RegisterHandler(parameters.svc),
+                        }
+                        parameters.expectFn(t, results)
+                    },
+                )
+            }
+        },
+    )
+    t.Run(
+        "ValidateRegex",
+        func(t *testing.T) {
+            type TestScenarioExpectParameters struct {
+                err error
+            }
+
+            type TestScenarioParameters struct {
+                regexValue string
+                isSubService bool
+                beginFn func(t *testing.T, handler *service.ServiceHandler)
+                expectFn func(t *testing.T, tsep TestScenarioExpectParameters)
+            }
+
+            type TestScenario struct {
+                name string
+                setup func(t *testing.T) TestScenarioParameters
+            }
+
+            var TestScenarios = []TestScenario{
+                {
+                    name: "invalid first char",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        return TestScenarioParameters{
+                            regexValue: "foo",
+                            isSubService: false,
+                            beginFn: func(t *testing.T, handler *service.ServiceHandler) {},
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if !errors.Is(tsep.err, service.ErrInvalidServiceRegex) {
+                                    t.Errorf("Unexpected error: %#v != %#v", tsep.err, service.ErrInvalidServiceRegex)
+                                }
+                            },
+                        }
+                    },
+                },
+                {
+                    name: "invalid last char",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        return TestScenarioParameters{
+                            regexValue: "^foo",
+                            isSubService: false,
+                            beginFn: func(t *testing.T, handler *service.ServiceHandler) {},
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if !errors.Is(tsep.err, service.ErrInvalidServiceRegex) {
+                                    t.Errorf("Unexpected error: %#v != %#v", tsep.err, service.ErrInvalidServiceRegex)
+                                }
+                            },
+                        }
+                    },
+                },
+                {
+                    name: "invalid last char for subservice",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        return TestScenarioParameters{
+                            regexValue: "^foo$",
+                            isSubService: true,
+                            beginFn: func(t *testing.T, handler *service.ServiceHandler) {},
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if !errors.Is(tsep.err, service.ErrInvalidServiceRegex) {
+                                    t.Errorf("Unexpected error: %#v != %#v", tsep.err, service.ErrInvalidServiceRegex)
+                                }
+                            },
+                        }
+                    },
+                },
+                {
+                    name: "success for no-subservice",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        return TestScenarioParameters{
+                            regexValue: "^foo$",
+                            isSubService: false,
+                            beginFn: func(t *testing.T, handler *service.ServiceHandler) {},
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if tsep.err != nil {
+                                    t.Errorf("Unexpected error: %#v", tsep.err)
+                                }
+                            },
+                        }
+                    },
+                },
+                {
+                    name: "success for subservice",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        return TestScenarioParameters{
+                            regexValue: "^foo",
+                            isSubService: true,
+                            beginFn: func(t *testing.T, handler *service.ServiceHandler) {},
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if tsep.err != nil {
+                                    t.Errorf("Unexpected error: %#v", tsep.err)
+                                }
+                            },
+                        }
+                    },
+                },
+            }
+
+            for _, scenario := range TestScenarios {
+                t.Run(
+                    scenario.name,
+                    func(t *testing.T) {
+                        handler := service.ServiceHandler{}
+
+                        parameters := scenario.setup(t)
+
+                        parameters.beginFn(t, &handler)
+
+                        results := TestScenarioExpectParameters{
+                            err: handler.ValidateRegex(parameters.regexValue, parameters.isSubService),
+                        }
+                        parameters.expectFn(t, results)
+                    },
+                )
+            }
+        },
+    )
+    t.Run(
+        "GetHandler",
+        func(t *testing.T) {
+            type TestScenarioExpectParameters struct {
+                err error
+                handler common.HttpHandler
+            }
+
+            type TestScenarioParameters struct {
+                inputUrl url.URL
+                beginFn func(t *testing.T, handler *service.ServiceHandler)
+                expectFn func(t *testing.T, tsep TestScenarioExpectParameters)
+            }
+
+            type TestScenario struct {
+                name string
+                setup func(t *testing.T) TestScenarioParameters
+            }
+
+            var TestScenarios = []TestScenario{
+                {
+                    name: "nil handler",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        theUrl, _ := url.Parse("https://foo.bar")
+                        theHandler := func(*common.HttpCall) (*common.HttpReply, error) {
+                            return nil, fmt.Errorf("Not implemented")
+                        }
+                        return TestScenarioParameters{
+                            inputUrl: *theUrl,
+                            beginFn: func(t *testing.T, handler *service.ServiceHandler) {
+                                handler.FuncHandler = theHandler
+                            },
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if tsep.err != nil {
+                                    t.Errorf("Unexpected error: %#v", tsep.err)
+                                }
+                                if tsep.handler == nil {
+                                    t.Errorf("Did not receive a handler")
+                                }
+                                // would be great if it could be proven the handler above is the
+                                // same one that got returned; unfortunately, that's not very easy
+                                // to do in Golang.
+                                /*
+                                f1 := &tsep.handler
+                                f2 := (*common.HttpHandler)(&theHandler)
+                                if !(f1 == f2) {
+                                    t.Errorf("Unexpected handler received: %#v != %#v", &tsep.handler, &theHandler)
+                                }
+                                */
+                            },
+                        }
+                    },
+                },
+                /*
+                {
+                    name: "success",
+                    setup: func(t *testing.T) TestScenarioParameters {
+                        theUrl, _ := url.Parse("https://foo.bar")
+                        theHandler := func(*common.HttpCall) (*common.HttpReply, error) {
+                            return nil, fmt.Errorf("Not implemented")
+                        }
+                        return TestScenarioParameters{
+                            inputUrl: *theUrl,
+                            beginFn: func(t *testing.T, handler *service.ServiceHandler) {
+                                handler.FuncHandler = theHandler
+                            },
+                            expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                                if tsep.handler == nil {
+                                    t.Errorf("Unexpected handler returned: %#p != %#p", tsep.handler, theHandler)
+                                }
+                                if tsep.err != nil {
+                                    t.Errorf("Unexpected error: %#v", tsep.err)
+                                }
+                            },
+                        }
+                    },
+                },
+                */
+            }
+
+            for _, scenario := range TestScenarios {
+                t.Run(
+                    scenario.name,
+                    func(t *testing.T) {
+                        handler := service.ServiceHandler{}
+
+                        parameters := scenario.setup(t)
+
+                        parameters.beginFn(t, &handler)
+
+                        subHandler, err := handler.GetHandler(parameters.inputUrl)
+                        results := TestScenarioExpectParameters{
+                            handler: subHandler,
+                            err: err,
+                        }
+                        parameters.expectFn(t, results)
+                    },
+                )
+            }
+        },
+    )
+}
+

--- a/service/servicemethodhandlermap.go
+++ b/service/servicemethodhandlermap.go
@@ -1,0 +1,9 @@
+package service
+
+import (
+)
+
+// map[service name][request method]service
+type ServiceMethodHandlerMap map[string]RequestMethodHandlerMap
+
+//func (smhm ServiceMethodHandlerMap) method() {return}

--- a/service/types.go
+++ b/service/types.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+    "errors"
+    "net/url"
+
+    "github.com/TestInABox/gostackinabox/common"
+)
+
+type Service interface {
+    IsSubService() bool
+    GetName() string
+    GetMatcher() common.URI
+    GetHandler(u url.URL) (common.HttpHandler, error)
+    RegisterHandler(subHandler Service) error
+    RegisterMethodHandler(method common.HttpVerb, handler common.HttpHandler) error
+    Init(name string, matcher common.URI) error
+}
+
+// map[service name]service
+type ServiceHandlerMap map[string]Service
+
+
+var (
+    ErrInvalidService error = errors.New("Service handler is invalid")
+    ErrInvalidServiceRegex error = errors.New("Invalid service regex")
+    ErrRequestHandlerInvalid error = errors.New("Service: Method Handler Invalid")
+    ErrRequestHandlerAlreadyRegister error = errors.New("Service: Method Already Registered")
+    ErrServiceHandlerAlreadyRegister error = errors.New("Service: Handler Already Registered")
+    ErrNoHandlerFunc error = errors.New("No handler func")
+
+    ErrNotImplemented error = errors.New("Not implemented")
+)

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,74 @@
+package util
+
+import (
+    "bytes"
+    "fmt"
+    "net/http"
+    "net/url"
+    "io"
+    "io/ioutil"
+)
+
+func StringToResponseBody(s string) io.ReadCloser {
+    b := bytes.NewBufferString(s)
+    r := bytes.NewReader(b.Bytes())
+    return ioutil.NopCloser(r)
+}
+
+func GetUrlBaseResource(url *url.URL) string {
+    if url != nil {
+        return fmt.Sprintf(
+            "%s://%s",
+            url.Scheme,
+            url.Host,
+        )
+    }
+
+    return ""
+}
+
+func EqualHeaders(l *http.Header, r *http.Header) (matches bool, err error) {
+    // if the left differs from the right then return false; otherwise return true
+    // NOTE: This is namely a test support function
+
+    // make sure there's something to compare
+    if l == nil || r == nil {
+        err = fmt.Errorf("Either left or right is an invalid pointer: Left (%v), Right (%v)", l, r)
+        matches = false
+        return
+    }
+
+    if len(*l) != len(*r) {
+        err = fmt.Errorf("Lengths do not match: %d ! %d\n", len(*l), len(*r))
+        matches = false
+        return
+    }
+
+    for lk, lv := range *l {
+        rv, ok := (*r)[lk]
+        if !ok {
+            err = fmt.Errorf("Key %v not found on the right\n", lk)
+            matches = false
+            return
+        }
+
+        if len(lv) != len(rv) {
+            err = fmt.Errorf("header %v  array length doesn't match: %d != %d\n", lk, len(lv), len(rv))
+            matches = false
+            return
+        }
+
+        for lvi, lvv := range lv {
+            rvv := rv[lvi]
+            if lvv != rvv {
+                err = fmt.Errorf("header %v array index %d doesn't match: %v != %v\n", lk, lvi, lvv, rvv)
+                matches = false
+                return
+            }
+        }
+    }
+
+    // length matches, and each value matches so they must be equal
+    matches = true
+    return
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,423 @@
+package util_test
+
+import (
+    "errors"
+    "fmt"
+    "io"
+    "net/http"
+    "net/url"
+    "strings"
+    "testing"
+
+    "github.com/TestInABox/gostackinabox/util"
+)
+
+
+func TestUtilStringToResponseBody(t *testing.T) {
+    type TestScenarioExpectParameters struct {
+        readCloser io.ReadCloser
+    }
+
+    type TestScenarioParameters struct {
+        value string
+        beginFn func(t *testing.T)
+        expectFn func(t *testing.T, tsep TestScenarioExpectParameters)
+    }
+
+    type TestScenario struct {
+        name string
+        setup func(t *testing.T) TestScenarioParameters
+    }
+
+    var TestScenarios = []TestScenario{
+        {
+            name: "null string",
+            setup: func(t *testing.T) TestScenarioParameters {
+                var emptyString string
+                var expectedReadCount int // = 0
+                readBufferSize := 100 // should be larger than the expectedReadCount
+                return TestScenarioParameters{
+                    value: emptyString,
+                    beginFn: func(t *testing.T) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.readCloser == nil {
+                            t.Error("Failed to get a read closer")
+                        } else {
+                            dataBuf := make([]byte, readBufferSize)
+                            count, readErr := tsep.readCloser.Read(dataBuf)
+                            if count != expectedReadCount {
+                                t.Errorf("Read %d bytes when %d were expected", count, expectedReadCount)
+                            }
+                            if !errors.Is(readErr, io.EOF) {
+                                t.Errorf("Received unexpected error: %v instead of %v", readErr, io.EOF)
+                            }
+                            resultValue := string(dataBuf[:count])
+                            compareResult := strings.Compare(resultValue, emptyString)
+
+                            t.Logf("Transfer Result: %d - %v", count, readErr)
+                            t.Logf("Original(%d): %s", len(emptyString), emptyString)
+                            t.Logf("Transfer(%d): %s", len(resultValue), resultValue)
+                            if compareResult != 0 {
+                                t.Errorf("Read \"%s\" when expecting \"%s\" - %d", resultValue, emptyString, compareResult)
+                            }
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "valid string",
+            setup: func(t *testing.T) TestScenarioParameters {
+                var stringValue string = "alpha beta delta gamma epsilon"
+                var expectedReadCount int = len(stringValue)
+                readBufferSize := 100 // should be larger than the expectedReadCount
+                return TestScenarioParameters{
+                    value: stringValue,
+                    beginFn: func(t *testing.T) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.readCloser == nil {
+                            t.Error("Failed to get a read closer")
+                        } else {
+                            dataBuf := make([]byte, readBufferSize)
+                            count, readErr := tsep.readCloser.Read(dataBuf)
+                            if count != expectedReadCount {
+                                t.Errorf("Read %d bytes when %d were expected", count, expectedReadCount)
+                            }
+                            if readErr != nil {
+                                t.Errorf("Received unexpected error: %v", readErr)
+                            }
+                            resultValue := string(dataBuf[:count])
+                            //if resultValue != stringValue {
+                            compareResult := strings.Compare(resultValue, stringValue)
+
+                            t.Logf("Transfer Result: %d - %v", count, readErr)
+                            t.Logf("Original(%d): %s", len(stringValue), stringValue)
+                            t.Logf("Transfer(%d): %s", len(resultValue), resultValue)
+                            if compareResult != 0 {
+                                t.Errorf("Read \"%s\" when expecting \"%s\"", resultValue, stringValue)
+                            }
+                        }
+                    },
+                }
+            },
+        },
+    }
+
+    for _, scenario := range TestScenarios {
+        t.Run(
+            scenario.name,
+            func(t *testing.T) {
+                parameters := scenario.setup(t)
+
+                parameters.beginFn(t)
+                result := util.StringToResponseBody(parameters.value)
+                parameters.expectFn(
+                    t,
+                    TestScenarioExpectParameters{
+                        readCloser: result,
+                    },
+                )
+            },
+        )
+    }
+}
+
+func TestUtilGetUrlBaseResource(t *testing.T) {
+    type TestScenarioExpectParameters struct {
+        BaseUrl string
+    }
+
+    type TestScenarioParameters struct {
+        inputUrl *url.URL
+        beginFn func(t *testing.T)
+        expectFn func(t *testing.T, tsep TestScenarioExpectParameters)
+    }
+
+    type TestScenario struct {
+        name string
+        setup func(t *testing.T) TestScenarioParameters
+    }
+
+    var TestScenarios = []TestScenario{
+        {
+            name: "invalid URL",
+            setup: func(t *testing.T) TestScenarioParameters {
+                return TestScenarioParameters {
+                    inputUrl: nil,
+                    beginFn: func(t *testing.T) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.BaseUrl != "" {
+                            t.Errorf("Received an unexpected URL value: \"%s\"", tsep.BaseUrl)
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "valid URL",
+            setup: func(t *testing.T) TestScenarioParameters {
+                baseUrl := "https://foobar"
+                fullUrl := fmt.Sprintf("%s/deadbeef/v1", baseUrl)
+                urlGen, urlGenErr := url.Parse(fullUrl)
+                if urlGenErr != nil {
+                    t.Errorf("Failed to generate the URL object: %v", urlGenErr)
+                }
+                return TestScenarioParameters {
+                    inputUrl: urlGen,
+                    beginFn: func(t *testing.T) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.BaseUrl != baseUrl {
+                            t.Errorf("Received \"%s\" when \"%s\" was expected", tsep.BaseUrl, baseUrl)
+                        }
+                    },
+                }
+            },
+        },
+    }
+
+    for _, scenario := range TestScenarios {
+        t.Run(
+            scenario.name,
+            func(t *testing.T) {
+                parameters := scenario.setup(t)
+
+                parameters.beginFn(t)
+
+                result := util.GetUrlBaseResource(parameters.inputUrl)
+                parameters.expectFn(
+                    t,
+                    TestScenarioExpectParameters{
+                        BaseUrl: result,
+                    },
+                )
+            },
+        )
+    }
+}
+
+func TestUtilEqualHeaders(t *testing.T) {
+    type TestScenarioExpectParameters struct {
+        result bool
+        err    error
+    }
+
+    type TestScenarioParameters struct {
+        leftHeader  *http.Header
+        rightHeader *http.Header
+        beginFn     func(t *testing.T)
+        expectFn    func(t *testing.T, tsep TestScenarioExpectParameters)
+    }
+
+    type TestScenario struct {
+        name string
+        setup func(t *testing.T) TestScenarioParameters
+    }
+
+    var TestScenarios = []TestScenario{
+        {
+            name: "nil left",
+            setup: func(t *testing.T) TestScenarioParameters {
+                rightHeader := make(http.Header)
+                return TestScenarioParameters{
+                    leftHeader: nil,
+                    rightHeader: &rightHeader,
+                    beginFn: func(t *testing.T) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.err == nil {
+                            t.Errorf("Failed to receive an expected error")
+                        }
+                        if tsep.result != false {
+                            t.Errorf("Unexpected received a match")
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "nil right",
+            setup: func(t *testing.T) TestScenarioParameters {
+                leftHeader := make(http.Header)
+                return TestScenarioParameters{
+                    leftHeader: &leftHeader,
+                    rightHeader: nil,
+                    beginFn: func(t *testing.T) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.err == nil {
+                            t.Errorf("Failed to receive an expected error")
+                        }
+                        if tsep.result != false {
+                            t.Errorf("Unexpected received a match")
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "lengths don't match",
+            setup: func(t *testing.T) TestScenarioParameters {
+                leftHeader := make(http.Header)
+                rightHeader := make(http.Header)
+                rightHeader["foo"] = []string{
+                    "bar",
+                    "d34d",
+                    "b33f",
+                }
+                return TestScenarioParameters{
+                    leftHeader: &leftHeader,
+                    rightHeader: &rightHeader,
+                    beginFn: func(t *testing.T) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.err == nil {
+                            t.Errorf("Failed to receive an expected error")
+                        }
+                        if tsep.result != false {
+                            t.Errorf("Unexpected received a match")
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "missing keys",
+            setup: func(t *testing.T) TestScenarioParameters {
+                leftHeader := make(http.Header)
+                leftHeader["bar"] = []string{
+                    "foo",
+                    "d34d",
+                    "b33f",
+                }
+                rightHeader := make(http.Header)
+                rightHeader["foo"] = []string{
+                    "bar",
+                    "d34d",
+                    "b33f",
+                }
+                return TestScenarioParameters{
+                    leftHeader: &leftHeader,
+                    rightHeader: &rightHeader,
+                    beginFn: func(t *testing.T) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.err == nil {
+                            t.Errorf("Failed to receive an expected error")
+                        }
+                        if tsep.result != false {
+                            t.Errorf("Unexpected received a match")
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "key value length match failure",
+            setup: func(t *testing.T) TestScenarioParameters {
+                leftHeader := make(http.Header)
+                leftHeader["foo"] = []string{
+                    "foo",
+                    "d34d",
+                    "b33f",
+                }
+                rightHeader := make(http.Header)
+                rightHeader["foo"] = []string{
+                    "bar",
+                    "d34d",
+                }
+                return TestScenarioParameters{
+                    leftHeader: &leftHeader,
+                    rightHeader: &rightHeader,
+                    beginFn: func(t *testing.T) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.err == nil {
+                            t.Errorf("Failed to receive an expected error")
+                        }
+                        if tsep.result != false {
+                            t.Errorf("Unexpected received a match")
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "key values match failure",
+            setup: func(t *testing.T) TestScenarioParameters {
+                leftHeader := make(http.Header)
+                leftHeader["foo"] = []string{
+                    "foo",
+                    "d34d",
+                    "b33f",
+                }
+                rightHeader := make(http.Header)
+                rightHeader["foo"] = []string{
+                    "foo",
+                    "d34d",
+                    "sortie",
+                }
+                return TestScenarioParameters{
+                    leftHeader: &leftHeader,
+                    rightHeader: &rightHeader,
+                    beginFn: func(t *testing.T) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.err == nil {
+                            t.Errorf("Failed to receive an expected error")
+                        }
+                        if tsep.result != false {
+                            t.Errorf("Unexpected received a match")
+                        }
+                    },
+                }
+            },
+        },
+        {
+            name: "success",
+            setup: func(t *testing.T) TestScenarioParameters {
+                leftHeader := make(http.Header)
+                leftHeader["foo"] = []string{
+                    "foo",
+                    "d34d",
+                    "b33f",
+                }
+                rightHeader := make(http.Header)
+                rightHeader["foo"] = []string{
+                    "foo",
+                    "d34d",
+                    "b33f",
+                }
+                return TestScenarioParameters{
+                    leftHeader: &leftHeader,
+                    rightHeader: &rightHeader,
+                    beginFn: func(t *testing.T) {},
+                    expectFn: func(t *testing.T, tsep TestScenarioExpectParameters) {
+                        if tsep.err != nil {
+                            t.Errorf("Unexpected received an error: %v", tsep.err)
+                        }
+                        if tsep.result != true {
+                            t.Errorf("Unexpected received a match failure")
+                        }
+                    },
+                }
+            },
+        },
+    }
+
+    for _, scenario := range TestScenarios {
+        t.Run(
+            scenario.name,
+            func(t *testing.T) {
+                parameters := scenario.setup(t)
+
+                parameters.beginFn(t)
+
+                result, err := util.EqualHeaders(
+                    parameters.leftHeader,
+                    parameters.rightHeader,
+                )
+                parameters.expectFn(
+                    t,
+                    TestScenarioExpectParameters{
+                        result: result,
+                        err: err,
+                    },
+                )
+            },
+        )
+    }
+}


### PR DESCRIPTION
- setup .gitignore, go.mod
- add Makefile for easy testing/coverage reporting
- add some basic README files for the various components
- add a default HTTP client similarly to how Golang's net/http does it
- add a object to represent the HTTP call, HTTP Reply, HTTP Status
- add URI matchers for server (base capture) and path (service handler)
- add common interfaces
- add logging
- add a router system that can integrate the stack
- add a tool for handling request to service mapping
- add a service handler for the main service, and subservice handler for components of the service
- add a common service interface
- add utilities to easier support of operations
- add unit tests for the various components